### PR TITLE
A custom port number wasn't always honored

### DIFF
--- a/Mockly.ApiVerificationTests/ApprovedApi/net472.verified.txt
+++ b/Mockly.ApiVerificationTests/ApprovedApi/net472.verified.txt
@@ -78,7 +78,7 @@ namespace Mockly
     {
         public RequestMock() { }
         public System.Collections.Generic.IEnumerable<Mockly.Matcher> CustomMatchers { get; }
-        public string? HostPattern { get; init; }
+        public string? HostPattern { get; set; }
         public int InvocationCount { get; }
         public uint? MaxInvocations { get; }
         public System.Net.Http.HttpMethod Method { get; init; }

--- a/Mockly.ApiVerificationTests/ApprovedApi/net8.0.verified.txt
+++ b/Mockly.ApiVerificationTests/ApprovedApi/net8.0.verified.txt
@@ -81,7 +81,7 @@ namespace Mockly
     {
         public RequestMock() { }
         public System.Collections.Generic.IEnumerable<Mockly.Matcher> CustomMatchers { get; }
-        public string? HostPattern { get; init; }
+        public string? HostPattern { get; set; }
         public int InvocationCount { get; }
         public uint? MaxInvocations { get; }
         public System.Net.Http.HttpMethod Method { get; init; }

--- a/Mockly.Specs/HttpMockSpecs.cs
+++ b/Mockly.Specs/HttpMockSpecs.cs
@@ -1202,11 +1202,24 @@ public class HttpMockSpecs
         }
 
         [Fact]
+        public async Task Can_provide_a_port_number()
+        {
+            var mock = new HttpMock();
+
+            mock.ForGet("https://api.example.com:7777/users/*?q=*")
+                .RespondsWithStatus(HttpStatusCode.OK);
+
+            var response = await mock.GetClient().GetAsync("https://api.example.com:7777/users/123?q=abc");
+
+            response.Should().Be200Ok();
+        }
+
+        [Fact]
         public async Task ForGet_with_wildcard_host_and_path_matches()
         {
             var mock = new HttpMock();
 
-            mock.ForGet("http://*.example.com/*")
+            mock.ForGet("http://*.example.com:80/*")
                 .RespondsWithStatus(HttpStatusCode.OK);
 
             var response = await mock.GetClient().GetAsync("http://shop.example.com/path/to/resource");
@@ -1219,7 +1232,7 @@ public class HttpMockSpecs
         {
             var mock = new HttpMock();
 
-            mock.ForPut("https://api.example.com/users/*?q=*")
+            mock.ForPut("https://api.example.com:443/users/*?q=*")
                 .RespondsWithStatus(HttpStatusCode.OK);
 
             var response = await mock.GetClient().PutAsync("https://api.example.com/users/42?q=term", new StringContent(""));

--- a/Mockly/Mockly.csproj
+++ b/Mockly/Mockly.csproj
@@ -11,7 +11,7 @@
     <TargetFrameworks>net8.0;net472</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Nullable>enable</Nullable>
-    <LangVersion>default</LangVersion>
+    <LangVersion>14</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <NoWarn>1591;1573</NoWarn>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>

--- a/Mockly/RequestMockBuilder.cs
+++ b/Mockly/RequestMockBuilder.cs
@@ -19,21 +19,16 @@ public class RequestMockBuilder
 {
     private readonly HttpMock mockBuilder;
     private readonly List<Matcher> customMatchers = new();
-    private readonly uint? maxInvocations;
     private string? pathPattern;
     private string? queryPattern;
-    private string? scheme;
-    private string? hostPattern;
+    private string? scheme = "https";
+    private string? hostPattern = "localhost";
     private RequestCollection? requestCollection;
 
     internal RequestMockBuilder(HttpMock mockBuilder, HttpMethod method)
     {
         this.mockBuilder = mockBuilder;
         Method = method;
-
-        // Defaults: https and localhost
-        scheme = "https";
-        hostPattern = "localhost";
     }
 
     /// <summary>
@@ -46,13 +41,8 @@ public class RequestMockBuilder
         Method = predecessor.Method;
 
         // Reuse only scheme and host
-        scheme = predecessor.scheme ?? "https";
-        hostPattern = predecessor.hostPattern ?? "localhost";
-
-        // Do NOT copy path/query/maxInvocations/custom matchers/response builders
-        pathPattern = null;
-        queryPattern = null;
-        maxInvocations = null;
+        scheme = predecessor.scheme ?? scheme;
+        hostPattern = predecessor.hostPattern ?? hostPattern;
     }
 
     internal HttpMethod Method { get; set; }
@@ -245,7 +235,6 @@ public class RequestMockBuilder
             HostPattern = hostPattern,
             CustomMatchers = customMatchers,
             RequestCollection = requestCollection,
-            MaxInvocations = maxInvocations,
             Responder = _ => new HttpResponseMessage(statusCode)
         };
 
@@ -275,7 +264,6 @@ public class RequestMockBuilder
             HostPattern = hostPattern,
             CustomMatchers = customMatchers,
             RequestCollection = requestCollection,
-            MaxInvocations = maxInvocations,
             Responder = _ =>
             {
                 var json = JsonSerializer.Serialize(content);
@@ -334,7 +322,6 @@ public class RequestMockBuilder
             HostPattern = hostPattern,
             CustomMatchers = customMatchers,
             RequestCollection = requestCollection,
-            MaxInvocations = maxInvocations,
             Responder = _ =>
             {
                 var payload = new Dictionary<string, object?>(StringComparer.Ordinal)
@@ -369,7 +356,6 @@ public class RequestMockBuilder
             HostPattern = hostPattern,
             CustomMatchers = customMatchers,
             RequestCollection = requestCollection,
-            MaxInvocations = maxInvocations,
             Responder = _ =>
             {
                 var payload = new Dictionary<string, object?>(StringComparer.Ordinal)
@@ -422,7 +408,6 @@ public class RequestMockBuilder
             HostPattern = hostPattern,
             CustomMatchers = customMatchers,
             RequestCollection = requestCollection,
-            MaxInvocations = maxInvocations,
             Responder = _ => new HttpResponseMessage(statusCode)
             {
                 Content = new StringContent(content, Encoding.UTF8, contentType)
@@ -447,7 +432,6 @@ public class RequestMockBuilder
             HostPattern = hostPattern,
             CustomMatchers = customMatchers,
             RequestCollection = requestCollection,
-            MaxInvocations = maxInvocations,
             Responder = _ => new HttpResponseMessage(statusCode)
         };
 
@@ -469,7 +453,6 @@ public class RequestMockBuilder
             HostPattern = hostPattern,
             CustomMatchers = customMatchers,
             RequestCollection = requestCollection,
-            MaxInvocations = maxInvocations,
             Responder = responder
         };
 


### PR DESCRIPTION
Fixes an issue where custom port numbers in host patterns were not always correctly honored during request matching. It introduces a normalization process that appends default ports (80 for HTTP, 443 for HTTPS) to host patterns if a specific port is missing. The matching logic was updated to compare against the full "host:port" string of incoming requests. Additionally, the project's C# language version was updated to 14, and some internal builder logic was cleaned up to improve default value handling.

Fixes #41 