### PR TITLE
Throwing an exception from RespondsWith will still count as a request

### DIFF
--- a/Mockly/RequestMock.cs
+++ b/Mockly/RequestMock.cs
@@ -251,15 +251,27 @@ public class RequestMock
     public CapturedRequest TrackRequest(RequestInfo request)
     {
         InvocationCount++;
-        HttpResponseMessage response = Responder(request);
 
         CapturedRequest capturedRequest = new(request)
         {
-            Response = response,
             Mock = this,
             WasExpected = true,
             Timestamp = DateTime.UtcNow
         };
+
+        try
+        {
+            capturedRequest.Response = Responder(request);
+        }
+#pragma warning disable CA1031
+        catch (Exception e)
+#pragma warning restore CA1031
+        {
+            capturedRequest.Response = new HttpResponseMessage(HttpStatusCode.InternalServerError)
+            {
+                ReasonPhrase = $"{e.GetType().Name}:{e.Message}"
+            };
+        }
 
         RequestCollection?.Add(capturedRequest);
 


### PR DESCRIPTION
Ensures that when a custom response handler throws an exception, the request is still correctly captured and tracked. The internal logic was updated to wrap the response generation in a try-catch block, preventing the exception from halting the tracking process. Instead of failing, the system now captures an "Internal Server Error" response containing the exception details. This change guarantees that even failing requests are added to the request collection for later verification.

#33 