### PR TITLE
Readme fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -683,6 +683,7 @@ var client = mock.GetClient();
 
 // Add more mocks later
 mock.ForPost().WithPath("/api/users").RespondsWithStatus(HttpStatusCode.Created);
+```
 
 Continue building can reuse parts of the previous builder for convenience. You can opt out with `Reset()`:
 


### PR DESCRIPTION
- Fix invocation limit function call order in examples
  The call order for the invocation limit functions (Once, Twice and Times) was wrong. They should be called after a Responds method.
- Added ending for continuing builder example code block
  The end tag for the continuing builder example code block was missing.