### PR TITLE
Include body of a request if it is textual in the failure

### DIFF
--- a/Mockly.ApiVerificationTests/ApprovedApi/net472.verified.txt
+++ b/Mockly.ApiVerificationTests/ApprovedApi/net472.verified.txt
@@ -68,11 +68,13 @@ namespace Mockly
     {
         public RequestInfo(System.Net.Http.HttpRequestMessage request, string? body) { }
         public string? Body { get; }
+        public string? ContentType { get; }
         public System.Net.Http.Headers.HttpRequestHeaders Headers { get; }
         public System.Net.Http.HttpMethod Method { get; set; }
         public System.Collections.Generic.IDictionary<string, object?> Properties { get; }
         public System.Uri? Uri { get; }
         public System.Version Version { get; set; }
+        public bool IsBodyLikelyTextual() { }
     }
     public class RequestMatchingException : System.Exception
     {

--- a/Mockly.ApiVerificationTests/ApprovedApi/net8.0.verified.txt
+++ b/Mockly.ApiVerificationTests/ApprovedApi/net8.0.verified.txt
@@ -70,12 +70,14 @@ namespace Mockly
     {
         public RequestInfo(System.Net.Http.HttpRequestMessage request, string? body) { }
         public string? Body { get; }
+        public string? ContentType { get; }
         public System.Net.Http.Headers.HttpRequestHeaders Headers { get; }
         public System.Net.Http.HttpMethod Method { get; set; }
         public System.Net.Http.HttpRequestOptions Options { get; }
         public System.Uri? Uri { get; }
         public System.Version Version { get; set; }
         public System.Net.Http.HttpVersionPolicy VersionPolicy { get; set; }
+        public bool IsBodyLikelyTextual() { }
     }
     public class RequestMatchingException : System.Exception
     {

--- a/Mockly.Specs/HttpMockSpecs.cs
+++ b/Mockly.Specs/HttpMockSpecs.cs
@@ -2,6 +2,7 @@ using System;
 using System.IO;
 using System.Net;
 using System.Net.Http;
+using System.Net.Http.Headers;
 using System.Text;
 using System.Threading.Tasks;
 using FluentAssertions;
@@ -856,7 +857,9 @@ public class HttpMockSpecs
                 .WithMessage(
                     """
                     Unexpected request to:
-                      GET https://localhost/fnv_collectiveschemes(111)
+                      GET https://localhost/fnv_collectiveschemes(111) with body of 0 bytes
+
+                    Note that you can further inspect the executed requests through the HttpMock.Requests property.
 
                     Closest matching mock:
                       GET https://localhost:443/fnv_collectiveschemes(123*)
@@ -890,11 +893,84 @@ public class HttpMockSpecs
             await act.Should().ThrowAsync<UnexpectedRequestException>()
                 .WithMessage("""
                              Unexpected request to:
-                               GET https://localhost/fnv_collectiveschemes(111)
+                               GET https://localhost/fnv_collectiveschemes(111) with body of 0 bytes
+
+                             Note that you can further inspect the executed requests through the HttpMock.Requests property.
 
                              Registered mocks:
                               - GET https://localhost:443/fnv_collectiveschemes
                              """);
+        }
+
+        [Fact]
+        public async Task Includes_the_body_if_it_is_textual()
+        {
+            // Arrange
+            var mock = new HttpMock();
+
+            mock
+                .ForPost().ForHttps().WithPath("/fnv_collectiveschemes")
+                .WithoutQuery()
+                .RespondsWithStatus(HttpStatusCode.Accepted);
+
+            HttpClient httpClient = mock.GetClient();
+
+            // Act
+            var act = () =>
+                httpClient.PostAsync("https://localhost/fnv_collectiveschemes(111)", new StringContent("Some string content"));
+
+            // Assert
+            await act.Should().ThrowAsync<UnexpectedRequestException>()
+                .WithMessage(
+                    """
+                    Unexpected request to:
+                      POST https://localhost/fnv_collectiveschemes(111) with body of 19 bytes
+
+                    Note that you can further inspect the executed requests through the HttpMock.Requests property.
+
+                    Registered mocks:
+                     - POST https://localhost:443/fnv_collectiveschemes
+
+                    Body (text/plain):
+                      "Some string content"
+                    """);
+        }
+
+        [Fact]
+        public async Task Omits_the_body_if_it_is_not_textual()
+        {
+            // Arrange
+            var mock = new HttpMock();
+
+            mock
+                .ForPost().ForHttps().WithPath("/fnv_collectiveschemes")
+                .WithoutQuery()
+                .RespondsWithStatus(HttpStatusCode.Accepted);
+
+            HttpClient httpClient = mock.GetClient();
+
+            // Act
+            var act = () =>
+                httpClient.PostAsync("https://localhost/fnv_collectiveschemes(111)", new ByteArrayContent([1, 2, 3])
+                {
+                    Headers = { ContentType = new MediaTypeHeaderValue("application/octet-stream") }
+                });
+
+            // Assert
+            await act.Should().ThrowAsync<UnexpectedRequestException>()
+                .WithMessage(
+                    """
+                    Unexpected request to:
+                      POST https://localhost/fnv_collectiveschemes(111) with body of 3 bytes
+
+                    Note that you can further inspect the executed requests through the HttpMock.Requests property.
+
+                    Registered mocks:
+                     - POST https://localhost:443/fnv_collectiveschemes
+
+                    Body (application/octet-stream):
+                      (binary content)
+                    """);
         }
     }
 
@@ -1712,7 +1788,17 @@ public class HttpMockSpecs
 
             // Assert
             response.StatusCode.Should().Be(HttpStatusCode.OK);
-            await response.Should().BeEquivalentTo(new { value = new[] { new { Id = 789, Name = "Bob Johnson" } } });
+            await response.Should().BeEquivalentTo(new
+            {
+                value = new[]
+                {
+                    new
+                    {
+                        Id = 789,
+                        Name = "Bob Johnson"
+                    }
+                }
+            });
         }
 
         [Fact]
@@ -1731,7 +1817,17 @@ public class HttpMockSpecs
 
             // Assert
             response.StatusCode.Should().Be(HttpStatusCode.Accepted);
-            await response.Should().BeEquivalentTo(new { value = new[] { new { Id = 999, Name = "Alice Brown" } } });
+            await response.Should().BeEquivalentTo(new
+            {
+                value = new[]
+                {
+                    new
+                    {
+                        Id = 999,
+                        Name = "Alice Brown"
+                    }
+                }
+            });
         }
 
         [Fact]
@@ -1757,9 +1853,21 @@ public class HttpMockSpecs
             {
                 value = new[]
                 {
-                    new { Id = 1, Name = "User 1" },
-                    new { Id = 2, Name = "User 2" },
-                    new { Id = 3, Name = "User 3" }
+                    new
+                    {
+                        Id = 1,
+                        Name = "User 1"
+                    },
+                    new
+                    {
+                        Id = 2,
+                        Name = "User 2"
+                    },
+                    new
+                    {
+                        Id = 3,
+                        Name = "User 3"
+                    }
                 }
             });
         }
@@ -1786,8 +1894,16 @@ public class HttpMockSpecs
             {
                 value = new[]
                 {
-                    new { Id = 10, Name = "Admin" },
-                    new { Id = 20, Name = "Manager" }
+                    new
+                    {
+                        Id = 10,
+                        Name = "Admin"
+                    },
+                    new
+                    {
+                        Id = 20,
+                        Name = "Manager"
+                    }
                 }
             });
         }
@@ -1813,7 +1929,17 @@ public class HttpMockSpecs
             // Assert
             response.StatusCode.Should().Be(HttpStatusCode.OK);
             content.Should().Contain("\"@odata.context\":\"" + context + "\"");
-            await response.Should().BeEquivalentTo(new { value = new[] { new { Id = 100, Name = "Context User" } } });
+            await response.Should().BeEquivalentTo(new
+            {
+                value = new[]
+                {
+                    new
+                    {
+                        Id = 100,
+                        Name = "Context User"
+                    }
+                }
+            });
         }
     }
 }

--- a/Mockly/HttpMock.cs
+++ b/Mockly/HttpMock.cs
@@ -1,11 +1,10 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Net;
-
+using System.Text;
+using Mockly.Common;
 #if NET472_OR_GREATER
 using System.Net.Http;
 #endif
-using System.Text;
-using Mockly.Common;
 
 #pragma warning disable CA1054
 
@@ -212,6 +211,7 @@ public class HttpMock
         {
             BaseAddress = new Uri("https://localhost/")
         };
+
         return client;
 #pragma warning restore CA2000
     }
@@ -286,7 +286,10 @@ public class HttpMock
 
         var messageBuilder = new StringBuilder();
         messageBuilder.AppendLine("Unexpected request to:");
-        messageBuilder.AppendLine($"  {request.Method} {request.Uri}");
+        messageBuilder.AppendLine($"  {request.Method} {request.Uri} with body of {request.Body?.Length ?? 0} bytes");
+
+        messageBuilder.AppendLine();
+        messageBuilder.AppendLine("Note that you can further inspect the executed requests through the HttpMock.Requests property.");
 
         if (closestMock != null && highestScore > 0)
         {
@@ -309,6 +312,21 @@ public class HttpMock
             {
                 messageBuilder.Append(" - ");
                 messageBuilder.AppendLine(mock.ToString());
+            }
+        }
+
+        if (request.Body is not null && request.Body.Length > 0)
+        {
+            messageBuilder.AppendLine();
+            messageBuilder.AppendLine($"Body ({request.ContentType}):");
+
+            if (request.IsBodyLikelyTextual())
+            {
+                messageBuilder.AppendLine($"  \"{request.Body}\"");
+            }
+            else
+            {
+                messageBuilder.AppendLine("  (binary content)");
             }
         }
 

--- a/Mockly/RequestInfo.cs
+++ b/Mockly/RequestInfo.cs
@@ -9,6 +9,11 @@ public class RequestInfo(HttpRequestMessage request, string? body)
 
     public string? Body { get; } = body;
 
+    /// <summary>
+    /// The content type of the request body, if any.
+    /// </summary>
+    public string? ContentType { get; } = request.Content?.Headers.ContentType?.MediaType;
+
     public HttpRequestHeaders Headers
     {
         get => request.Headers;
@@ -44,5 +49,58 @@ public class RequestInfo(HttpRequestMessage request, string? body)
     {
         get => request.Version;
         set => request.Version = value;
+    }
+
+    /// <summary>
+    /// Determines if the request body is likely to be textual based on the Content-Type header.
+    /// </summary>
+    /// <returns>
+    /// Returns true if the Content-Type indicates a textual media type (e.g., text/*, application/json,
+    /// application/xml, or other known textual types). Returns false otherwise.
+    /// </returns>
+    public bool IsBodyLikelyTextual()
+    {
+        string? mediaType = ContentType;
+
+        if (mediaType == null)
+        {
+            return false;
+        }
+
+        if (string.IsNullOrWhiteSpace(mediaType))
+        {
+            return false;
+        }
+
+#pragma warning disable CA1308
+        mediaType = mediaType.Trim().ToLowerInvariant();
+#pragma warning restore CA1308
+
+        // Any text/* is textual
+        if (mediaType.StartsWith("text/", StringComparison.Ordinal))
+        {
+            return true;
+        }
+
+        // RFC 6839 structured syntax suffixes
+        if (mediaType.EndsWith("+json", StringComparison.Ordinal) ||
+            mediaType.EndsWith("+xml", StringComparison.Ordinal) ||
+            mediaType.EndsWith("+yaml", StringComparison.Ordinal) ||
+            mediaType.EndsWith("+yml", StringComparison.Ordinal) ||
+            mediaType.EndsWith("+csv", StringComparison.Ordinal))
+        {
+            return true;
+        }
+
+        // Common "application/*" textual types
+        return mediaType is
+            "application/json" or
+            "application/xml" or
+            "application/xhtml+xml" or
+            "application/javascript" or
+            "application/ecmascript" or
+            "application/x-www-form-urlencoded" or
+            "application/graphql" or
+            "application/sql";
     }
 }


### PR DESCRIPTION
This commit enriches the error produced when an unexpected HTTP request is received by always appending the request body size to the request line (e.g., “with body of N bytes”). It also captures the request body’s media type and uses it to decide whether the body is likely textual. When the body is present and deemed textual, the failure message includes the quoted body content; otherwise it prints the content type and a “(binary content)” placeholder instead of dumping bytes. The public surface was updated to expose the body content type and the helper used for that “textual vs binary” decision.

E.g.

```
Unexpected request to:
  POST https://localhost/fnv_collectiveschemes(111) with body of 19 bytes

Note that you can further inspect the executed requests through the HttpMock.Requests property.

Registered mocks:
 - POST https://localhost:443/fnv_collectiveschemes

Body (text/plain):
  "Some string content"
```

Fixes #55