### PR TITLE
Include the differences when using WithBodyEquivalentTo

### DIFF
--- a/Mockly.ApiVerificationTests/ApprovedApi/net472.verified.txt
+++ b/Mockly.ApiVerificationTests/ApprovedApi/net472.verified.txt
@@ -15,6 +15,7 @@ namespace Mockly
         public string Query { get; }
         public System.Net.Http.HttpResponseMessage Response { get; }
         public string Scheme { get; }
+        public int Sequence { get; set; }
         public System.DateTime Timestamp { get; }
         public System.Uri? Uri { get; }
         public System.Version Version { get; }

--- a/Mockly.ApiVerificationTests/ApprovedApi/net8.0.verified.txt
+++ b/Mockly.ApiVerificationTests/ApprovedApi/net8.0.verified.txt
@@ -16,6 +16,7 @@ namespace Mockly
         public string Query { get; }
         public System.Net.Http.HttpResponseMessage Response { get; }
         public string Scheme { get; }
+        public int Sequence { get; set; }
         public System.DateTime Timestamp { get; }
         public System.Uri? Uri { get; }
         public System.Version Version { get; }

--- a/Mockly.Specs/AssertionSpecs.cs
+++ b/Mockly.Specs/AssertionSpecs.cs
@@ -481,7 +481,12 @@ public class AssertionSpecs
                 .WithBodyEquivalentTo(expected);
 
             // Assert
-            act.Should().Throw<XunitException>();
+            act.Should().Throw<XunitException>().WithMessage(
+                """
+                Expected request #1 (POST https://localhost/api/test) to have a body equivalent to the expectation, but it did not:
+                - Expected property actual.id to be 2, but found 1.
+                - Expected property actual.name to be "y", but "x" differs near "x" (index 0).*
+                """);
         }
     }
 
@@ -500,17 +505,19 @@ public class AssertionSpecs
             await client.PostAsync("https://localhost/api/test", new StringContent("{ \"id\":\"1\", \"name\":\"x\" }"));
 
             // Assert
-            mock.Requests.Should().ContainRequest().WithBodyHavingPropertiesOf(new Dictionary<string, string>(StringComparer.Ordinal)
-            {
-                ["id"] = "1",
-                ["name"] = "x"
-            });
+            mock.Requests.Should().ContainRequest().WithBodyHavingPropertiesOf(
+                new Dictionary<string, string>(StringComparer.Ordinal)
+                {
+                    ["id"] = "1",
+                    ["name"] = "x"
+                });
 
-            mock.Requests.Should().ContainRequest().WithBodyHavingPropertiesOf(new Dictionary<string, string>(StringComparer.Ordinal)
-            {
-                ["id"] = "2",
-                ["name"] = "y"
-            });
+            mock.Requests.Should().ContainRequest().WithBodyHavingPropertiesOf(
+                new Dictionary<string, string>(StringComparer.Ordinal)
+                {
+                    ["id"] = "2",
+                    ["name"] = "y"
+                });
         }
 
         [Fact]

--- a/Mockly/CapturedRequest.cs
+++ b/Mockly/CapturedRequest.cs
@@ -107,11 +107,14 @@ public class CapturedRequest(RequestInfo request)
         get => request.Version;
     }
 
+    /// <summary>
+    /// The sequence number of the captured request, starting at 1.
+    /// </summary>
+    public int Sequence { get; set; }
+
     public override string ToString()
     {
-        string route = $"{Method} {Scheme}://{Host}{Path}{Query}";
-
-        return route;
+        return $"{Method} {Scheme}://{Host}{Path}{Query}";
     }
 
 }

--- a/Mockly/RequestCollection.cs
+++ b/Mockly/RequestCollection.cs
@@ -18,6 +18,7 @@ public class RequestCollection : IEnumerable<CapturedRequest>
     internal void Add(CapturedRequest request)
     {
         requests.Add(request);
+        request.Sequence = requests.Count;
     }
 
     /// <summary>


### PR DESCRIPTION
This commit adds a per-request sequence number (starting at 1) and assigns it when requests are recorded, so failures can refer to a specific request instance. 

It also improves the `WithBodyEquivalentTo` assertion failure output by tracking the “closest” request (the one with the fewest equivalency failures) and including its sequence and request summary in the error message. Instead of a generic “none matched” message, the failure now lists the specific differences as bullet points, making it easier to see why the expected body didn’t match:

```csharp
mock.Requests.Should().ContainRequest().WithBodyEquivalentTo(new
{
    id = 2,
    name = "y"
});
```

If that fails, the result will look like

```
Expected request #1 (POST https://localhost/api/test) to have a body equivalent to the expectation, but it did not:
- Expected property actual.id to be 2, but found 1.
- Expected property actual.name to be "y", but "x" differs near "x" (index 0).*
```


Fixes #54 