### PR TITLE
Add request header matching

### DIFF
--- a/Mockly.ApiVerificationTests/ApprovedApi/net472.verified.txt
+++ b/Mockly.ApiVerificationTests/ApprovedApi/net472.verified.txt
@@ -131,10 +131,14 @@ namespace Mockly
         public Mockly.RequestMockBuilder With(System.Func<Mockly.RequestInfo, System.Threading.Tasks.Task<bool>> matcher, [System.Runtime.CompilerServices.CallerArgumentExpression("matcher")] string? matcherText = null) { }
         public Mockly.RequestMockBuilder With(System.Func<Mockly.RequestInfo, bool> matcher, [System.Runtime.CompilerServices.CallerArgumentExpression("matcher")] string? matcherText = null) { }
         public Mockly.RequestMockBuilder WithAnyQuery() { }
+        public Mockly.RequestMockBuilder WithBearerToken(string tokenPattern = "*") { }
         public Mockly.RequestMockBuilder WithBody(object body) { }
         public Mockly.RequestMockBuilder WithBody(string wildcardPattern) { }
         public Mockly.RequestMockBuilder WithBodyMatchingJson(string json) { }
         public Mockly.RequestMockBuilder WithBodyMatchingRegex(string regex) { }
+        public Mockly.RequestMockBuilder WithContentType(string mediaTypePattern) { }
+        public Mockly.RequestMockBuilder WithHeader(string name) { }
+        public Mockly.RequestMockBuilder WithHeader(string name, string valuePattern) { }
         public Mockly.RequestMockBuilder WithPath(string wildcardPattern) { }
         public Mockly.RequestMockBuilder WithQuery(string wildcardPattern) { }
         public Mockly.RequestMockBuilder WithoutQuery() { }

--- a/Mockly.ApiVerificationTests/ApprovedApi/net8.0.verified.txt
+++ b/Mockly.ApiVerificationTests/ApprovedApi/net8.0.verified.txt
@@ -134,10 +134,14 @@ namespace Mockly
         public Mockly.RequestMockBuilder With(System.Func<Mockly.RequestInfo, System.Threading.Tasks.Task<bool>> matcher, [System.Runtime.CompilerServices.CallerArgumentExpression("matcher")] string? matcherText = null) { }
         public Mockly.RequestMockBuilder With(System.Func<Mockly.RequestInfo, bool> matcher, [System.Runtime.CompilerServices.CallerArgumentExpression("matcher")] string? matcherText = null) { }
         public Mockly.RequestMockBuilder WithAnyQuery() { }
+        public Mockly.RequestMockBuilder WithBearerToken(string tokenPattern = "*") { }
         public Mockly.RequestMockBuilder WithBody(object body) { }
         public Mockly.RequestMockBuilder WithBody(string wildcardPattern) { }
         public Mockly.RequestMockBuilder WithBodyMatchingJson(string json) { }
         public Mockly.RequestMockBuilder WithBodyMatchingRegex([System.Diagnostics.CodeAnalysis.StringSyntax("Regex")] string regex) { }
+        public Mockly.RequestMockBuilder WithContentType(string mediaTypePattern) { }
+        public Mockly.RequestMockBuilder WithHeader(string name) { }
+        public Mockly.RequestMockBuilder WithHeader(string name, string valuePattern) { }
         public Mockly.RequestMockBuilder WithPath(string wildcardPattern) { }
         public Mockly.RequestMockBuilder WithQuery(string wildcardPattern) { }
         public Mockly.RequestMockBuilder WithoutQuery() { }

--- a/Mockly.Specs/HttpMockSpecs.cs
+++ b/Mockly.Specs/HttpMockSpecs.cs
@@ -509,6 +509,32 @@ public class HttpMockSpecs
         }
 
         [Fact]
+        public void Throws_when_the_header_name_is_null()
+        {
+            // Arrange
+            var mock = new HttpMock();
+
+            // Act
+            Action act = () => mock.ForGet().WithHeader(null!);
+
+            // Assert
+            act.Should().Throw<ArgumentNullException>().WithParameterName("name");
+        }
+
+        [Fact]
+        public void Throws_when_the_header_name_or_value_pattern_is_null()
+        {
+            // Arrange
+            var mock = new HttpMock();
+
+            // Act
+            Action act = () => mock.ForGet().WithHeader("X-Correlation-Id", null!);
+
+            // Assert
+            act.Should().Throw<ArgumentNullException>().WithParameterName("valuePattern");
+        }
+
+        [Fact]
         public async Task Matches_when_the_header_value_satisfies_the_wildcard_pattern()
         {
             // Arrange
@@ -540,6 +566,26 @@ public class HttpMockSpecs
 
             var client = mock.GetClient();
             client.DefaultRequestHeaders.Add("X-Correlation-Id", "xyz-123");
+
+            // Act
+            var act = () => client.GetAsync("https://localhost/api/test");
+
+            // Assert
+            await act.Should().ThrowAsync<UnexpectedRequestException>()
+                .WithMessage("*header \"X-Correlation-Id\" matches \"abc-*\"*");
+        }
+
+        [Fact]
+        public async Task Reports_the_value_requirement_when_the_header_is_missing()
+        {
+            // Arrange
+            var mock = new HttpMock();
+            mock.ForGet()
+                .WithPath("/api/test")
+                .WithHeader("X-Correlation-Id", "abc-*")
+                .RespondsWithStatus(HttpStatusCode.OK);
+
+            var client = mock.GetClient();
 
             // Act
             var act = () => client.GetAsync("https://localhost/api/test");
@@ -632,6 +678,39 @@ public class HttpMockSpecs
         }
 
         [Fact]
+        public void Throws_when_the_bearer_token_pattern_is_null()
+        {
+            // Arrange
+            var mock = new HttpMock();
+
+            // Act
+            Action act = () => mock.ForGet().WithBearerToken(null!);
+
+            // Assert
+            act.Should().Throw<ArgumentNullException>().WithParameterName("tokenPattern");
+        }
+
+        [Fact]
+        public async Task Reports_the_bearer_token_requirement_when_the_authorization_header_is_missing()
+        {
+            // Arrange
+            var mock = new HttpMock();
+            mock.ForGet()
+                .WithPath("/api/test")
+                .WithBearerToken()
+                .RespondsWithStatus(HttpStatusCode.OK);
+
+            var client = mock.GetClient();
+
+            // Act
+            var act = () => client.GetAsync("https://localhost/api/test");
+
+            // Assert
+            await act.Should().ThrowAsync<UnexpectedRequestException>()
+                .WithMessage("*bearer token matches \"*\"*");
+        }
+
+        [Fact]
         public async Task Matches_the_content_type_media_type_ignoring_parameters()
         {
             // Arrange
@@ -652,6 +731,19 @@ public class HttpMockSpecs
         }
 
         [Fact]
+        public void Throws_when_the_content_type_pattern_is_null()
+        {
+            // Arrange
+            var mock = new HttpMock();
+
+            // Act
+            Action act = () => mock.ForPost().WithContentType(null!);
+
+            // Assert
+            act.Should().Throw<ArgumentNullException>().WithParameterName("mediaTypePattern");
+        }
+
+        [Fact]
         public async Task Reports_the_content_type_requirement_when_the_media_type_does_not_match()
         {
             // Arrange
@@ -666,6 +758,26 @@ public class HttpMockSpecs
 
             // Act
             var act = () => client.PostAsync("https://localhost/api/test", content);
+
+            // Assert
+            await act.Should().ThrowAsync<UnexpectedRequestException>()
+                .WithMessage("*content type matches \"application/json\"*");
+        }
+
+        [Fact]
+        public async Task Reports_the_content_type_requirement_when_the_content_type_is_missing()
+        {
+            // Arrange
+            var mock = new HttpMock();
+            mock.ForPost()
+                .WithPath("/api/test")
+                .WithContentType("application/json")
+                .RespondsWithStatus(HttpStatusCode.NoContent);
+
+            var client = mock.GetClient();
+
+            // Act
+            var act = () => client.PostAsync("https://localhost/api/test", null);
 
             // Assert
             await act.Should().ThrowAsync<UnexpectedRequestException>()

--- a/Mockly.Specs/HttpMockSpecs.cs
+++ b/Mockly.Specs/HttpMockSpecs.cs
@@ -466,6 +466,213 @@ public class HttpMockSpecs
         }
     }
 
+    public class HeaderMatching
+    {
+        [Fact]
+        public async Task Matches_when_the_header_is_present()
+        {
+            // Arrange
+            var mock = new HttpMock();
+            mock.ForGet()
+                .WithPath("/api/test")
+                .WithHeader("X-Api-Key")
+                .RespondsWithStatus(HttpStatusCode.OK);
+
+            var client = mock.GetClient();
+            client.DefaultRequestHeaders.Add("X-Api-Key", "secret");
+
+            // Act
+            var response = await client.GetAsync("https://localhost/api/test");
+
+            // Assert
+            response.StatusCode.Should().Be(HttpStatusCode.OK);
+        }
+
+        [Fact]
+        public async Task Reports_the_header_requirement_when_the_header_is_missing()
+        {
+            // Arrange
+            var mock = new HttpMock();
+            mock.ForGet()
+                .WithPath("/api/test")
+                .WithHeader("X-Api-Key")
+                .RespondsWithStatus(HttpStatusCode.OK);
+
+            var client = mock.GetClient();
+
+            // Act
+            var act = () => client.GetAsync("https://localhost/api/test");
+
+            // Assert
+            await act.Should().ThrowAsync<UnexpectedRequestException>()
+                .WithMessage("*header \"X-Api-Key\" is present*");
+        }
+
+        [Fact]
+        public async Task Matches_when_the_header_value_satisfies_the_wildcard_pattern()
+        {
+            // Arrange
+            var mock = new HttpMock();
+            mock.ForGet()
+                .WithPath("/api/test")
+                .WithHeader("X-Correlation-Id", "abc-*")
+                .RespondsWithStatus(HttpStatusCode.OK);
+
+            var client = mock.GetClient();
+            client.DefaultRequestHeaders.Add("X-Correlation-Id", "abc-123");
+
+            // Act
+            var response = await client.GetAsync("https://localhost/api/test");
+
+            // Assert
+            response.StatusCode.Should().Be(HttpStatusCode.OK);
+        }
+
+        [Fact]
+        public async Task Reports_the_value_requirement_when_the_header_value_does_not_match()
+        {
+            // Arrange
+            var mock = new HttpMock();
+            mock.ForGet()
+                .WithPath("/api/test")
+                .WithHeader("X-Correlation-Id", "abc-*")
+                .RespondsWithStatus(HttpStatusCode.OK);
+
+            var client = mock.GetClient();
+            client.DefaultRequestHeaders.Add("X-Correlation-Id", "xyz-123");
+
+            // Act
+            var act = () => client.GetAsync("https://localhost/api/test");
+
+            // Assert
+            await act.Should().ThrowAsync<UnexpectedRequestException>()
+                .WithMessage("*header \"X-Correlation-Id\" matches \"abc-*\"*");
+        }
+
+        [Fact]
+        public async Task Matches_when_any_value_of_a_multi_valued_header_satisfies_the_pattern()
+        {
+            // Arrange
+            var mock = new HttpMock();
+            mock.ForGet()
+                .WithPath("/api/test")
+                .WithHeader("Accept", "application/json")
+                .RespondsWithStatus(HttpStatusCode.OK);
+
+            var client = mock.GetClient();
+            client.DefaultRequestHeaders.Add("Accept", "text/plain");
+            client.DefaultRequestHeaders.Add("Accept", "application/json");
+
+            // Act
+            var response = await client.GetAsync("https://localhost/api/test");
+
+            // Assert
+            response.StatusCode.Should().Be(HttpStatusCode.OK);
+        }
+
+        [Fact]
+        public async Task Matches_a_bearer_token_by_default()
+        {
+            // Arrange
+            var mock = new HttpMock();
+            mock.ForGet()
+                .WithPath("/api/test")
+                .WithBearerToken()
+                .RespondsWithStatus(HttpStatusCode.OK);
+
+            var client = mock.GetClient();
+            client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", "any-token");
+
+            // Act
+            var response = await client.GetAsync("https://localhost/api/test");
+
+            // Assert
+            response.StatusCode.Should().Be(HttpStatusCode.OK);
+        }
+
+        [Fact]
+        public async Task Matches_a_bearer_token_against_a_wildcard_pattern()
+        {
+            // Arrange
+            var mock = new HttpMock();
+            mock.ForGet()
+                .WithPath("/api/test")
+                .WithBearerToken("eyJ*")
+                .RespondsWithStatus(HttpStatusCode.OK);
+
+            var client = mock.GetClient();
+            client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", "eyJhbGciOiJ");
+
+            // Act
+            var response = await client.GetAsync("https://localhost/api/test");
+
+            // Assert
+            response.StatusCode.Should().Be(HttpStatusCode.OK);
+        }
+
+        [Fact]
+        public async Task Reports_the_bearer_token_requirement_when_the_scheme_is_not_bearer()
+        {
+            // Arrange
+            var mock = new HttpMock();
+            mock.ForGet()
+                .WithPath("/api/test")
+                .WithBearerToken()
+                .RespondsWithStatus(HttpStatusCode.OK);
+
+            var client = mock.GetClient();
+            client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Basic", "dXNlcjpwYXNz");
+
+            // Act
+            var act = () => client.GetAsync("https://localhost/api/test");
+
+            // Assert
+            await act.Should().ThrowAsync<UnexpectedRequestException>()
+                .WithMessage("*bearer token matches \"*\"*");
+        }
+
+        [Fact]
+        public async Task Matches_the_content_type_media_type_ignoring_parameters()
+        {
+            // Arrange
+            var mock = new HttpMock();
+            mock.ForPost()
+                .WithPath("/api/test")
+                .WithContentType("application/json")
+                .RespondsWithStatus(HttpStatusCode.NoContent);
+
+            var client = mock.GetClient();
+            var content = new StringContent("{}", Encoding.UTF8, "application/json");
+
+            // Act
+            var response = await client.PostAsync("https://localhost/api/test", content);
+
+            // Assert
+            response.StatusCode.Should().Be(HttpStatusCode.NoContent);
+        }
+
+        [Fact]
+        public async Task Reports_the_content_type_requirement_when_the_media_type_does_not_match()
+        {
+            // Arrange
+            var mock = new HttpMock();
+            mock.ForPost()
+                .WithPath("/api/test")
+                .WithContentType("application/json")
+                .RespondsWithStatus(HttpStatusCode.NoContent);
+
+            var client = mock.GetClient();
+            var content = new StringContent("plain", Encoding.UTF8, "text/plain");
+
+            // Act
+            var act = () => client.PostAsync("https://localhost/api/test", content);
+
+            // Assert
+            await act.Should().ThrowAsync<UnexpectedRequestException>()
+                .WithMessage("*content type matches \"application/json\"*");
+        }
+    }
+
     public class AdvancedMatching
     {
         [Fact]

--- a/Mockly/RequestMockBuilder.cs
+++ b/Mockly/RequestMockBuilder.cs
@@ -215,6 +215,102 @@ public class RequestMockBuilder
     }
 
     /// <summary>
+    /// Configures the request mock to match requests that contain the specified header, regardless of its value.
+    /// </summary>
+    /// <param name="name">The name of the header that must be present on the request.</param>
+    /// <exception cref="ArgumentNullException"><paramref name="name"/> is <c>null</c>.</exception>
+    public RequestMockBuilder WithHeader(string name)
+    {
+        if (name is null)
+        {
+            throw new ArgumentNullException(nameof(name));
+        }
+
+        return With(
+            request => request.Headers.TryGetValues(name, out _),
+            $"header \"{name}\" is present");
+    }
+
+    /// <summary>
+    /// Configures the request mock to match requests that contain the specified header with a value satisfying the
+    /// given wildcard pattern. For headers with multiple values, a match on any single value is sufficient.
+    /// </summary>
+    /// <param name="name">The name of the header that must be present on the request.</param>
+    /// <param name="valuePattern">
+    /// The wildcard pattern used to match the header value, where '?' represents any single character and '*' represents
+    /// any sequence of characters.
+    /// </param>
+    /// <exception cref="ArgumentNullException">
+    /// <paramref name="name"/> or <paramref name="valuePattern"/> is <c>null</c>.
+    /// </exception>
+    public RequestMockBuilder WithHeader(string name, string valuePattern)
+    {
+        if (name is null)
+        {
+            throw new ArgumentNullException(nameof(name));
+        }
+
+        if (valuePattern is null)
+        {
+            throw new ArgumentNullException(nameof(valuePattern));
+        }
+
+        return With(
+            request => request.Headers.TryGetValues(name, out var values) &&
+                values.Any(value => value.MatchesWildcard(valuePattern)),
+            $"header \"{name}\" matches \"{valuePattern}\"");
+    }
+
+    /// <summary>
+    /// Configures the request mock to match requests that carry an <c>Authorization</c> header using the <c>Bearer</c>
+    /// scheme with a token satisfying the given wildcard pattern.
+    /// </summary>
+    /// <param name="tokenPattern">
+    /// The wildcard pattern used to match the bearer token, where '?' represents any single character and '*' represents
+    /// any sequence of characters. Defaults to '*', which matches any non-empty token.
+    /// </param>
+    /// <exception cref="ArgumentNullException"><paramref name="tokenPattern"/> is <c>null</c>.</exception>
+    public RequestMockBuilder WithBearerToken(string tokenPattern = "*")
+    {
+        if (tokenPattern is null)
+        {
+            throw new ArgumentNullException(nameof(tokenPattern));
+        }
+
+        return With(
+            request =>
+            {
+                var authorization = request.Headers.Authorization;
+                return authorization is not null &&
+                    string.Equals(authorization.Scheme, "Bearer", StringComparison.OrdinalIgnoreCase) &&
+                    authorization.Parameter is not null &&
+                    authorization.Parameter.MatchesWildcard(tokenPattern);
+            },
+            $"bearer token matches \"{tokenPattern}\"");
+    }
+
+    /// <summary>
+    /// Configures the request mock to match requests whose <c>Content-Type</c> media type satisfies the given wildcard
+    /// pattern. Any parameters such as <c>charset</c> are ignored; only the media type is compared.
+    /// </summary>
+    /// <param name="mediaTypePattern">
+    /// The wildcard pattern used to match the media type, where '?' represents any single character and '*' represents
+    /// any sequence of characters.
+    /// </param>
+    /// <exception cref="ArgumentNullException"><paramref name="mediaTypePattern"/> is <c>null</c>.</exception>
+    public RequestMockBuilder WithContentType(string mediaTypePattern)
+    {
+        if (mediaTypePattern is null)
+        {
+            throw new ArgumentNullException(nameof(mediaTypePattern));
+        }
+
+        return With(
+            request => request.ContentType is not null && request.ContentType.MatchesWildcard(mediaTypePattern),
+            $"content type matches \"{mediaTypePattern}\"");
+    }
+
+    /// <summary>
     /// Specifies a custom matcher predicate for the request.
     /// </summary>
     public RequestMockBuilder With(Func<RequestInfo, bool> matcher,

--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ Unlike other HTTP mocking libraries, Mockly offers:
 
 * **Fluent, intuitive API** - Chain method calls to build complex mocking scenarios with ease
 * **Wildcard pattern matching** - Match URLs using wildcards (`*`) in paths and query strings
+* **First-class header matching** - Match request headers, bearer tokens, and content types directly
 * **Custom matchers** - Use predicates for advanced request matching logic
 * **Request capture & inspection** - Automatically capture all requests with full metadata (headers, body, timestamp)
 * **Powerful assertions** - Built-in FluentAssertions extensions for verifying HTTP behavior
@@ -74,6 +75,9 @@ Mockly is created and maintained by [Dennis Doomen](https://github.com/dennisdoo
 ```csharp
 mock.ForGet().WithPath("/api/users/*").RespondsWithJsonContent(user);
 mock.ForPost().WithPath("/api/data").WithQuery("?filter=*").RespondsWithStatus(HttpStatusCode.Created);
+mock.ForGet().WithPath("/api/secure").WithHeader("X-Api-Key").RespondsWithStatus(HttpStatusCode.OK);
+mock.ForPost().WithPath("/api/auth").WithBearerToken("eyJ*").RespondsWithStatus(HttpStatusCode.OK);
+mock.ForPost().WithPath("/api/json").WithContentType("application/json").RespondsWithStatus(HttpStatusCode.OK);
 ```
 
 ### 📃 Clear Reporting

--- a/SKILL.md
+++ b/SKILL.md
@@ -3,7 +3,7 @@ name: mockly
 description: >
   Helps write tests using Mockly — a fluent HTTP mocking library for .NET that intercepts HttpClient
   calls. Use this skill when writing unit or integration tests that need to mock HTTP requests,
-  configure responses (status codes, JSON, OData, raw content), capture and inspect requests,
+  configure responses (status codes, JSON, OData, raw content), match headers, capture and inspect requests,
   limit mock invocations, or assert HTTP interactions with FluentAssertions.
 ---
 
@@ -49,9 +49,17 @@ mock.ForPost().WithPath("/api/data").WithBody(new { name = "John" }).RespondsWit
 mock.ForPost().WithPath("/api/data").WithBodyMatchingJson("{\"name\":\"John\"}").RespondsWithStatus(HttpStatusCode.NoContent);
 mock.ForPost().WithPath("/api/data").WithBodyMatchingRegex(".*keyword.*").RespondsWithStatus(HttpStatusCode.NoContent);
 
-// Custom predicate (sync or async) — also use .With() for header/URI checks
+// Custom predicate (sync or async) — use .With() for custom body or URI checks
 mock.ForPost().WithPath("/api/data").With(req => req.Body!.Contains("keyword")).RespondsWithStatus(HttpStatusCode.NoContent);
-mock.ForGet().WithPath("/api/secure").With(req => req.Headers.Contains("X-API-Key")).RespondsWithStatus(HttpStatusCode.OK);
+```
+
+## Header Matching
+
+```csharp
+mock.ForGet().WithPath("/api/secure").WithHeader("X-API-Key").RespondsWithStatus(HttpStatusCode.OK);
+mock.ForGet().WithPath("/api/secure").WithHeader("X-Trace-Id", "abc-*").RespondsWithStatus(HttpStatusCode.OK);
+mock.ForGet().WithPath("/api/auth").WithBearerToken().RespondsWithStatus(HttpStatusCode.OK);
+mock.ForPost().WithPath("/api/json").WithContentType("application/json").RespondsWithStatus(HttpStatusCode.OK);
 ```
 
 ## Responses

--- a/website/docs/usage.md
+++ b/website/docs/usage.md
@@ -105,6 +105,34 @@ mock.ForGet()
     .WithQuery("?q=*&limit=10");
 ```
 
+## Header Matching
+
+Use the first-class header matchers when you need to assert on common request metadata:
+
+```csharp
+mock.ForGet()
+    .WithPath("/api/secure")
+    .WithHeader("X-Api-Key")
+    .RespondsWithStatus(HttpStatusCode.OK);
+
+mock.ForGet()
+    .WithPath("/api/secure")
+    .WithHeader("X-Trace-Id", "abc-*")
+    .RespondsWithStatus(HttpStatusCode.OK);
+
+mock.ForGet()
+    .WithPath("/api/auth")
+    .WithBearerToken("eyJ*")
+    .RespondsWithStatus(HttpStatusCode.OK);
+
+mock.ForPost()
+    .WithPath("/api/json")
+    .WithContentType("application/json")
+    .RespondsWithStatus(HttpStatusCode.OK);
+```
+
+`WithHeader(name, valuePattern)` matches when any value of a multi-valued header satisfies the wildcard pattern. `WithContentType` matches the media type and ignores parameters such as `charset`.
+
 ## Response Configuration
 
 ### JSON Responses


### PR DESCRIPTION
Closes #114

## Summary

Adds first-class fluent matchers for request headers to `RequestMockBuilder`, so users no longer have to fall back to a raw `With(predicate)` for the very common case of matching on headers (auth tokens, API keys, content negotiation, correlation ids). Each matcher is registered as a `Matcher` instance with a descriptive `displayText` so it surfaces in the existing closest-match diagnostics.

## New API

```csharp
public RequestMockBuilder WithHeader(string name);                       // header present
public RequestMockBuilder WithHeader(string name, string valuePattern);  // value wildcard match
public RequestMockBuilder WithBearerToken(string tokenPattern = "*");    // Authorization: Bearer ...
public RequestMockBuilder WithContentType(string mediaTypePattern);      // matches Content-Type media type
```

- Value matching reuses the existing wildcard helper (`MatchesWildcard`), so `*`/`?` patterns work consistently with the rest of the library.
- Multi-valued headers match if **any** value satisfies the pattern.
- `WithContentType` reads `RequestInfo.ContentType`, ignoring parameters such as `charset`.
- `WithBearerToken` matches the `Authorization` header with the `Bearer` scheme and applies the wildcard pattern to the token (defaults to `*`).

## Tests

Added a `HeaderMatching` nested class in `Mockly.Specs` covering presence match, value wildcard match, negative-match diagnostics (header missing, value mismatch, wrong auth scheme, content-type mismatch), and multi-valued headers.

## Verification

- `./build.ps1` is green (Compile, RunInspectCode/analyzers, RunTests, ApiChecks all succeeded across `net472` + `net8.0`).
- Public API change accepted via `./AcceptApiChanges.ps1`; updated `*.verified.txt` files committed.

## Follow-up

The companion `FluentAssertions.Mockly` assertion methods (`WithHeader`, `WithBearerToken` on `ContainedRequestAssertions`) described in #114 live in the separate `dennisdoomen/fluentassertions.mockly` repository and require a separate PR there. They are intentionally **not** part of this PR.