### PR TITLE
Expose RequestMock invocation state for per-mock assertions

### DIFF
--- a/Mockly.Specs/HttpMockSpecs.cs
+++ b/Mockly.Specs/HttpMockSpecs.cs
@@ -2899,4 +2899,34 @@ public class HttpMockSpecs
     }
 #nullable restore
 
+    public class InvocationTracking
+    {
+        [Fact]
+        public async Task Configured_mock_exposes_its_invocation_count_after_calls()
+        {
+            // Arrange
+            var mock = new HttpMock();
+            var responseBuilder = mock.ForGet().WithPath("api/test").RespondsWithStatus(HttpStatusCode.OK);
+
+            // Act
+            await mock.GetClient().GetAsync("https://localhost/api/test");
+            await mock.GetClient().GetAsync("https://localhost/api/test");
+
+            // Assert
+            responseBuilder.RequestMock.InvocationCount.Should().Be(2);
+        }
+
+        [Fact]
+        public void Configured_mock_exposes_its_invocation_limit()
+        {
+            // Arrange
+            var mock = new HttpMock();
+
+            // Act
+            var responseBuilder = mock.ForGet().WithPath("api/test").RespondsWithStatus(HttpStatusCode.OK).Twice();
+
+            // Assert
+            responseBuilder.RequestMock.MaxInvocations.Should().Be(2);
+        }
+    }
 }

--- a/Mockly/RequestMockResponseBuilder.cs
+++ b/Mockly/RequestMockResponseBuilder.cs
@@ -13,6 +13,13 @@ public class RequestMockResponseBuilder
     }
 
     /// <summary>
+    /// Gets the underlying <see cref="RequestMock"/> so the assertion packages can inspect
+    /// per-mock invocation state such as <see cref="RequestMock.InvocationCount"/> and
+    /// <see cref="RequestMock.MaxInvocations"/>.
+    /// </summary>
+    internal RequestMock RequestMock => requestMock;
+
+    /// <summary>
     /// Limits this mock to be used exactly once.
     /// </summary>
     public RequestMockResponseBuilder Once()


### PR DESCRIPTION
Closes #121

## Summary

This is the **core-repo enabler only** for per-mock invocation assertions. It exposes the underlying `RequestMock` from `RequestMockResponseBuilder` so the `FluentAssertions.Mockly` packages can read per-mock invocation state (`InvocationCount` / `MaxInvocations`) when implementing the actual assertion methods.

### Changes
- Added an `internal RequestMock RequestMock` accessor on `RequestMockResponseBuilder`. The existing `[InternalsVisibleTo]` entries for `FluentAssertions.Mockly.v7` and `FluentAssertions.Mockly.v8` already cover these assemblies, so no widening of the public surface was needed (`RequestMock.InvocationCount` and `MaxInvocations` are already public).
- Added unit tests in `Mockly.Specs` proving a configured mock's invocation count and invocation limit are observable after calls.

### Design notes
- Purely additive and backward-compatible. No consumer-facing breaking changes.
- Preferred `InternalsVisibleTo` + internal members over widening the public API, per the issue's breaking-change analysis.
- The public approved-API snapshot is **unchanged** — the API verification tests pass without regeneration.

### Verification
- `./build.ps1` succeeds end-to-end (Compile, RunInspectCode analyzers, RunTests, ApiChecks all green).
- New `InvocationTracking` specs pass.

## Follow-up

⚠️ The actual `HaveBeenCalled(Times...)`, `NotHaveBeenCalled()`, and `HaveCalledInOrder(...)` assertion methods are **NOT** part of this PR. They live in the separate **[dennisdoomen/fluentassertions.mockly](https://github.com/dennisdoomen/fluentassertions.mockly)** repository, which is the primary home for this feature, and will be delivered in a separate PR there (including its own API verification snapshot update via `AcceptApiChanges.ps1`). This PR only unblocks that work by making the per-mock invocation state visible to the assertion assemblies.

Do not merge until the follow-up assertions PR is ready / reviewed.