### PR TITLE
Add generic For(HttpMethod), ForHead, ForOptions (closes #119)

### DIFF
--- a/Mockly.ApiVerificationTests/ApprovedApi/net472.verified.txt
+++ b/Mockly.ApiVerificationTests/ApprovedApi/net472.verified.txt
@@ -30,10 +30,16 @@ namespace Mockly
         public bool PrefetchBody { get; set; }
         public Mockly.RequestCollection Requests { get; }
         public void Clear() { }
+        public Mockly.RequestMockBuilder For(System.Net.Http.HttpMethod method) { }
+        public Mockly.RequestMockBuilder For(System.Net.Http.HttpMethod method, string urlPattern) { }
         public Mockly.RequestMockBuilder ForDelete() { }
         public Mockly.RequestMockBuilder ForDelete(string urlPattern) { }
         public Mockly.RequestMockBuilder ForGet() { }
         public Mockly.RequestMockBuilder ForGet(string urlPattern) { }
+        public Mockly.RequestMockBuilder ForHead() { }
+        public Mockly.RequestMockBuilder ForHead(string urlPattern) { }
+        public Mockly.RequestMockBuilder ForOptions() { }
+        public Mockly.RequestMockBuilder ForOptions(string urlPattern) { }
         public Mockly.RequestMockBuilder ForPatch() { }
         public Mockly.RequestMockBuilder ForPatch(string urlPattern) { }
         public Mockly.RequestMockBuilder ForPost() { }

--- a/Mockly.ApiVerificationTests/ApprovedApi/net8.0.verified.txt
+++ b/Mockly.ApiVerificationTests/ApprovedApi/net8.0.verified.txt
@@ -32,10 +32,16 @@ namespace Mockly
         public bool PrefetchBody { get; set; }
         public Mockly.RequestCollection Requests { get; }
         public void Clear() { }
+        public Mockly.RequestMockBuilder For(System.Net.Http.HttpMethod method) { }
+        public Mockly.RequestMockBuilder For(System.Net.Http.HttpMethod method, string urlPattern) { }
         public Mockly.RequestMockBuilder ForDelete() { }
         public Mockly.RequestMockBuilder ForDelete(string urlPattern) { }
         public Mockly.RequestMockBuilder ForGet() { }
         public Mockly.RequestMockBuilder ForGet(string urlPattern) { }
+        public Mockly.RequestMockBuilder ForHead() { }
+        public Mockly.RequestMockBuilder ForHead(string urlPattern) { }
+        public Mockly.RequestMockBuilder ForOptions() { }
+        public Mockly.RequestMockBuilder ForOptions(string urlPattern) { }
         public Mockly.RequestMockBuilder ForPatch() { }
         public Mockly.RequestMockBuilder ForPatch(string urlPattern) { }
         public Mockly.RequestMockBuilder ForPost() { }

--- a/Mockly.Specs/HttpMockSpecs.cs
+++ b/Mockly.Specs/HttpMockSpecs.cs
@@ -2548,4 +2548,245 @@ public class HttpMockSpecs
 #endif
     }
 
+    public class GenericAndAdditionalVerbs
+    {
+        [Fact]
+        public async Task Can_mock_head_request()
+        {
+            // Arrange
+            var mock = new HttpMock();
+
+            mock.ForHead()
+                .WithPath("/api/resource")
+                .RespondsWithStatus(HttpStatusCode.OK);
+
+            var client = mock.GetClient();
+
+            // Act
+            var request = new HttpRequestMessage(HttpMethod.Head, "https://localhost/api/resource");
+            var response = await client.SendAsync(request);
+
+            // Assert
+            response.StatusCode.Should().Be(HttpStatusCode.OK);
+        }
+
+        [Fact]
+        public async Task Can_mock_head_request_using_url_pattern()
+        {
+            // Arrange
+            var mock = new HttpMock();
+
+            mock.ForHead("https://localhost/api/resource")
+                .RespondsWithStatus(HttpStatusCode.OK);
+
+            var client = mock.GetClient();
+
+            // Act
+            var request = new HttpRequestMessage(HttpMethod.Head, "https://localhost/api/resource");
+            var response = await client.SendAsync(request);
+
+            // Assert
+            response.StatusCode.Should().Be(HttpStatusCode.OK);
+        }
+
+        [Fact]
+        public async Task Can_mock_options_request()
+        {
+            // Arrange
+            var mock = new HttpMock();
+
+            mock.ForOptions()
+                .WithPath("/api/resource")
+                .RespondsWithStatus(HttpStatusCode.NoContent);
+
+            var client = mock.GetClient();
+
+            // Act
+            var request = new HttpRequestMessage(HttpMethod.Options, "https://localhost/api/resource");
+            var response = await client.SendAsync(request);
+
+            // Assert
+            response.StatusCode.Should().Be(HttpStatusCode.NoContent);
+        }
+
+        [Fact]
+        public async Task Can_mock_options_request_using_url_pattern()
+        {
+            // Arrange
+            var mock = new HttpMock();
+
+            mock.ForOptions("https://localhost/api/resource")
+                .RespondsWithStatus(HttpStatusCode.NoContent);
+
+            var client = mock.GetClient();
+
+            // Act
+            var request = new HttpRequestMessage(HttpMethod.Options, "https://localhost/api/resource");
+            var response = await client.SendAsync(request);
+
+            // Assert
+            response.StatusCode.Should().Be(HttpStatusCode.NoContent);
+        }
+
+        [Fact]
+        public async Task Can_mock_request_using_generic_for_with_standard_method()
+        {
+            // Arrange
+            var mock = new HttpMock();
+
+            mock.For(HttpMethod.Get)
+                .WithPath("/api/data")
+                .RespondsWithStatus(HttpStatusCode.OK);
+
+            var client = mock.GetClient();
+
+            // Act
+            var response = await client.GetAsync("https://localhost/api/data");
+
+            // Assert
+            response.StatusCode.Should().Be(HttpStatusCode.OK);
+        }
+
+        [Fact]
+        public async Task Can_mock_request_using_generic_for_with_custom_method()
+        {
+            // Arrange
+            var mock = new HttpMock();
+
+            mock.For(new HttpMethod("PROPFIND"))
+                .WithPath("/api/dav")
+                .RespondsWithStatus(HttpStatusCode.OK);
+
+            var client = mock.GetClient();
+
+            // Act
+            var request = new HttpRequestMessage(new HttpMethod("PROPFIND"), "https://localhost/api/dav");
+            var response = await client.SendAsync(request);
+
+            // Assert
+            response.StatusCode.Should().Be(HttpStatusCode.OK);
+        }
+
+        [Fact]
+        public async Task Generic_for_does_not_match_a_different_method()
+        {
+            // Arrange
+            var mock = new HttpMock();
+
+            mock.For(new HttpMethod("PROPFIND"))
+                .WithPath("/api/dav")
+                .RespondsWithStatus(HttpStatusCode.OK);
+
+            var client = mock.GetClient();
+
+            // Act
+            var act = () => client.GetAsync("https://localhost/api/dav");
+
+            // Assert
+            await act.Should().ThrowAsync<UnexpectedRequestException>();
+        }
+
+        [Fact]
+        public async Task Can_mock_request_using_generic_for_with_url_pattern()
+        {
+            // Arrange
+            var mock = new HttpMock();
+
+            mock.For(HttpMethod.Options, "https://localhost/api/resource")
+                .RespondsWithStatus(HttpStatusCode.NoContent);
+
+            var client = mock.GetClient();
+
+            // Act
+            var request = new HttpRequestMessage(HttpMethod.Options, "https://localhost/api/resource");
+            var response = await client.SendAsync(request);
+
+            // Assert
+            response.StatusCode.Should().Be(HttpStatusCode.NoContent);
+        }
+
+        [Fact]
+        public async Task New_verbs_reuse_scheme_and_host_from_previous_builder()
+        {
+            // Arrange
+            var mock = new HttpMock();
+
+            mock.ForGet()
+                .ForHttps().ForHost("somehost")
+                .WithPath("/api/test")
+                .RespondsWithStatus(HttpStatusCode.OK);
+
+            // Reuse the previous builder's scheme and host for an OPTIONS mock
+            mock.ForOptions()
+                .WithPath("/api/test")
+                .RespondsWithStatus(HttpStatusCode.NoContent);
+
+            var client = mock.GetClient();
+
+            // Act
+            var getResponse = await client.GetAsync("https://somehost/api/test");
+            var optionsRequest = new HttpRequestMessage(HttpMethod.Options, "https://somehost/api/test");
+            var optionsResponse = await client.SendAsync(optionsRequest);
+
+            // Assert
+            getResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+            optionsResponse.StatusCode.Should().Be(HttpStatusCode.NoContent);
+        }
+
+        [Fact]
+        public async Task Generic_for_with_schemeless_url_pattern_matches_any_scheme()
+        {
+            // Arrange
+            var mock = new HttpMock();
+
+            mock.For(HttpMethod.Get, "localhost/api/data")
+                .RespondsWithStatus(HttpStatusCode.OK);
+
+            var client = mock.GetClient();
+
+            // Act
+            var response = await client.GetAsync("https://localhost/api/data");
+
+            // Assert
+            response.StatusCode.Should().Be(HttpStatusCode.OK);
+        }
+
+        [Fact]
+        public async Task Generic_for_with_host_only_url_pattern_matches()
+        {
+            // Arrange
+            var mock = new HttpMock();
+
+            mock.For(HttpMethod.Head, "https://localhost")
+                .RespondsWithStatus(HttpStatusCode.OK);
+
+            var client = mock.GetClient();
+
+            // Act
+            var request = new HttpRequestMessage(HttpMethod.Head, "https://localhost/");
+            var response = await client.SendAsync(request);
+
+            // Assert
+            response.StatusCode.Should().Be(HttpStatusCode.OK);
+        }
+
+        [Fact]
+        public async Task Generic_for_with_host_and_query_url_pattern_matches()
+        {
+            // Arrange
+            var mock = new HttpMock();
+
+            mock.For(HttpMethod.Get, "https://localhost?q=1")
+                .RespondsWithStatus(HttpStatusCode.OK);
+
+            var client = mock.GetClient();
+
+            // Act
+            var response = await client.GetAsync("https://localhost/?q=1");
+
+            // Assert
+            response.StatusCode.Should().Be(HttpStatusCode.OK);
+        }
+    }
+
 }

--- a/Mockly/HttpMock.cs
+++ b/Mockly/HttpMock.cs
@@ -41,20 +41,31 @@ public class HttpMock
     public RequestCollection Requests { get; } = new();
 
     /// <summary>
+    /// Starts building a mock for requests using the specified HTTP <paramref name="method"/>.
+    /// Reuses settings from the previous request if available.
+    /// </summary>
+    public RequestMockBuilder For(HttpMethod method)
+    {
+        return Create(method);
+    }
+
+    /// <summary>
+    /// Shortcut overload that accepts a full URL pattern (supports wildcards) and configures scheme, host, path and query.
+    /// </summary>
+    public RequestMockBuilder For(HttpMethod method, string urlPattern)
+    {
+        var builder = ApplyUrlPattern(Create(method), urlPattern);
+        previousBuilder = builder;
+        return builder;
+    }
+
+    /// <summary>
     /// Starts building a mock for GET requests.
     /// Reuses settings from the previous request if available.
     /// </summary>
     public RequestMockBuilder ForGet()
     {
-        RequestMockBuilder mockBuilder = previousBuilder != null
-            ? new RequestMockBuilder(this, previousBuilder)
-            {
-                Method = HttpMethod.Get
-            }
-            : new RequestMockBuilder(this, HttpMethod.Get);
-
-        previousBuilder = mockBuilder;
-        return mockBuilder;
+        return Create(HttpMethod.Get);
     }
 
     /// <summary>
@@ -62,10 +73,7 @@ public class HttpMock
     /// </summary>
     public RequestMockBuilder ForGet(string urlPattern)
     {
-        var builder = ForGet();
-        builder = ApplyUrlPattern(builder, urlPattern);
-        previousBuilder = builder;
-        return builder;
+        return For(HttpMethod.Get, urlPattern);
     }
 
     /// <summary>
@@ -74,15 +82,7 @@ public class HttpMock
     /// </summary>
     public RequestMockBuilder ForPost()
     {
-        var builder = previousBuilder != null
-            ? new RequestMockBuilder(this, previousBuilder)
-            {
-                Method = HttpMethod.Post
-            }
-            : new RequestMockBuilder(this, HttpMethod.Post);
-
-        previousBuilder = builder;
-        return builder;
+        return Create(HttpMethod.Post);
     }
 
     /// <summary>
@@ -90,10 +90,7 @@ public class HttpMock
     /// </summary>
     public RequestMockBuilder ForPost(string urlPattern)
     {
-        var builder = ForPost();
-        builder = ApplyUrlPattern(builder, urlPattern);
-        previousBuilder = builder;
-        return builder;
+        return For(HttpMethod.Post, urlPattern);
     }
 
     /// <summary>
@@ -102,15 +99,7 @@ public class HttpMock
     /// </summary>
     public RequestMockBuilder ForPut()
     {
-        var builder = previousBuilder != null
-            ? new RequestMockBuilder(this, previousBuilder)
-            {
-                Method = HttpMethod.Put
-            }
-            : new RequestMockBuilder(this, HttpMethod.Put);
-
-        previousBuilder = builder;
-        return builder;
+        return Create(HttpMethod.Put);
     }
 
     /// <summary>
@@ -118,10 +107,7 @@ public class HttpMock
     /// </summary>
     public RequestMockBuilder ForPut(string urlPattern)
     {
-        var builder = ForPut();
-        builder = ApplyUrlPattern(builder, urlPattern);
-        previousBuilder = builder;
-        return builder;
+        return For(HttpMethod.Put, urlPattern);
     }
 
     /// <summary>
@@ -130,15 +116,7 @@ public class HttpMock
     /// </summary>
     public RequestMockBuilder ForPatch()
     {
-        var builder = previousBuilder != null
-            ? new RequestMockBuilder(this, previousBuilder)
-            {
-                Method = new HttpMethod("PATCH")
-            }
-            : new RequestMockBuilder(this, new HttpMethod("PATCH"));
-
-        previousBuilder = builder;
-        return builder;
+        return Create(new HttpMethod("PATCH"));
     }
 
     /// <summary>
@@ -146,10 +124,7 @@ public class HttpMock
     /// </summary>
     public RequestMockBuilder ForPatch(string urlPattern)
     {
-        var builder = ForPatch();
-        builder = ApplyUrlPattern(builder, urlPattern);
-        previousBuilder = builder;
-        return builder;
+        return For(new HttpMethod("PATCH"), urlPattern);
     }
 
     /// <summary>
@@ -158,15 +133,7 @@ public class HttpMock
     /// </summary>
     public RequestMockBuilder ForDelete()
     {
-        var builder = previousBuilder != null
-            ? new RequestMockBuilder(this, previousBuilder)
-            {
-                Method = HttpMethod.Delete
-            }
-            : new RequestMockBuilder(this, HttpMethod.Delete);
-
-        previousBuilder = builder;
-        return builder;
+        return Create(HttpMethod.Delete);
     }
 
     /// <summary>
@@ -174,8 +141,52 @@ public class HttpMock
     /// </summary>
     public RequestMockBuilder ForDelete(string urlPattern)
     {
-        var builder = ForDelete();
-        builder = ApplyUrlPattern(builder, urlPattern);
+        return For(HttpMethod.Delete, urlPattern);
+    }
+
+    /// <summary>
+    /// Starts building a mock for HEAD requests.
+    /// Reuses settings from the previous request if available.
+    /// </summary>
+    public RequestMockBuilder ForHead()
+    {
+        return Create(HttpMethod.Head);
+    }
+
+    /// <summary>
+    /// Shortcut overload that accepts a full URL pattern (supports wildcards) and configures scheme, host, path and query.
+    /// </summary>
+    public RequestMockBuilder ForHead(string urlPattern)
+    {
+        return For(HttpMethod.Head, urlPattern);
+    }
+
+    /// <summary>
+    /// Starts building a mock for OPTIONS requests.
+    /// Reuses settings from the previous request if available.
+    /// </summary>
+    public RequestMockBuilder ForOptions()
+    {
+        return Create(HttpMethod.Options);
+    }
+
+    /// <summary>
+    /// Shortcut overload that accepts a full URL pattern (supports wildcards) and configures scheme, host, path and query.
+    /// </summary>
+    public RequestMockBuilder ForOptions(string urlPattern)
+    {
+        return For(HttpMethod.Options, urlPattern);
+    }
+
+    private RequestMockBuilder Create(HttpMethod method)
+    {
+        RequestMockBuilder builder = previousBuilder != null
+            ? new RequestMockBuilder(this, previousBuilder)
+            {
+                Method = method
+            }
+            : new RequestMockBuilder(this, method);
+
         previousBuilder = builder;
         return builder;
     }

--- a/SKILL.md
+++ b/SKILL.md
@@ -21,6 +21,23 @@ mock.ForGet().WithPath("/api/users").RespondsWithStatus(HttpStatusCode.OK);
 HttpClient client = mock.GetClient(); // or mock.GetClientFactory()
 ```
 
+## HTTP Verbs
+
+```csharp
+// Convenience methods per verb (each also has a "(urlPattern)" overload)
+mock.ForGet();
+mock.ForPost();
+mock.ForPut();
+mock.ForPatch();
+mock.ForDelete();
+mock.ForHead();
+mock.ForOptions();
+
+// Generic entry point for any (including non-standard) verb
+mock.For(HttpMethod.Get).WithPath("/api/data").RespondsWithStatus(HttpStatusCode.OK);
+mock.For(new HttpMethod("PROPFIND"), "https://localhost/dav/*").RespondsWithStatus(HttpStatusCode.OK);
+```
+
 ## URL Matching
 
 ```csharp


### PR DESCRIPTION
Closes #119

## Summary

Adds a generic `For(HttpMethod)` entry point plus `ForHead()` and `ForOptions()` convenience methods to `HttpMock`, complementing the existing `ForGet/ForPost/ForPut/ForPatch/ForDelete`.

As part of this, the repeated `previousBuilder != null ? copy-ctor : new` logic that was duplicated in every `ForXxx` method has been extracted into a single private `Create(HttpMethod)` helper. All existing `ForXxx` methods plus the new ones now delegate to it; the URL-pattern overloads reuse the existing `ApplyUrlPattern` helper. This refactor is internal and behavior-preserving — all existing specs still pass.

## New public API (additive, backward-compatible)

```csharp
RequestMockBuilder For(HttpMethod method);
RequestMockBuilder For(HttpMethod method, string urlPattern);
RequestMockBuilder ForHead();
RequestMockBuilder ForHead(string urlPattern);
RequestMockBuilder ForOptions();
RequestMockBuilder ForOptions(string urlPattern);
```

## Tests & coverage

Added a `GenericAndAdditionalVerbs` nested spec class covering:
- HEAD and OPTIONS matching + responding (including URL-pattern overloads)
- `For(HttpMethod)` with a standard method
- `For(custom method)` matching a non-standard verb (`PROPFIND`) and not matching a different verb
- scheme/host reuse from the previous builder for the new verbs
- scheme-less, host-only and host+query URL patterns (exercising previously-untested `ApplyUrlPattern` branches)

`HttpMock` line coverage improved from ~0.886 to ~0.958; coverage is non-decreasing.

## Docs

`SKILL.md` (the API cheat sheet referenced by `AGENTS.md`) gains an "HTTP Verbs" section documenting all convenience verbs and the generic `For`.

## Verification

- Rebased onto current `main` (includes #125 header matching and #137 AGENTS.md).
- `./build.ps1` is green — Compile, RunInspectCode analyzers, RunTests (116 specs), ApiChecks, and Pack all succeeded with warnings-as-errors.
- API approval files under `Mockly.ApiVerificationTests/ApprovedApi` regenerated via `AcceptApiChanges.ps1`.

Draft for maintainer review — not for merge.