### PR TITLE
Add query-parameter and form-field matchers 

### DIFF
--- a/Mockly.ApiVerificationTests/ApprovedApi/net472.verified.txt
+++ b/Mockly.ApiVerificationTests/ApprovedApi/net472.verified.txt
@@ -147,10 +147,13 @@ namespace Mockly
         public Mockly.RequestMockBuilder WithBodyMatchingJson(string json) { }
         public Mockly.RequestMockBuilder WithBodyMatchingRegex(string regex) { }
         public Mockly.RequestMockBuilder WithContentType(string mediaTypePattern) { }
+        public Mockly.RequestMockBuilder WithFormField(string name, string valuePattern) { }
         public Mockly.RequestMockBuilder WithHeader(string name) { }
         public Mockly.RequestMockBuilder WithHeader(string name, string valuePattern) { }
         public Mockly.RequestMockBuilder WithPath(string wildcardPattern) { }
         public Mockly.RequestMockBuilder WithQuery(string wildcardPattern) { }
+        public Mockly.RequestMockBuilder WithQueryParam(string name) { }
+        public Mockly.RequestMockBuilder WithQueryParam(string name, string valuePattern) { }
         public Mockly.RequestMockBuilder WithoutQuery() { }
     }
     public class RequestMockResponseBuilder

--- a/Mockly.ApiVerificationTests/ApprovedApi/net8.0.verified.txt
+++ b/Mockly.ApiVerificationTests/ApprovedApi/net8.0.verified.txt
@@ -150,10 +150,13 @@ namespace Mockly
         public Mockly.RequestMockBuilder WithBodyMatchingJson(string json) { }
         public Mockly.RequestMockBuilder WithBodyMatchingRegex([System.Diagnostics.CodeAnalysis.StringSyntax("Regex")] string regex) { }
         public Mockly.RequestMockBuilder WithContentType(string mediaTypePattern) { }
+        public Mockly.RequestMockBuilder WithFormField(string name, string valuePattern) { }
         public Mockly.RequestMockBuilder WithHeader(string name) { }
         public Mockly.RequestMockBuilder WithHeader(string name, string valuePattern) { }
         public Mockly.RequestMockBuilder WithPath(string wildcardPattern) { }
         public Mockly.RequestMockBuilder WithQuery(string wildcardPattern) { }
+        public Mockly.RequestMockBuilder WithQueryParam(string name) { }
+        public Mockly.RequestMockBuilder WithQueryParam(string name, string valuePattern) { }
         public Mockly.RequestMockBuilder WithoutQuery() { }
     }
     public class RequestMockResponseBuilder

--- a/Mockly.Specs/HttpMockSpecs.cs
+++ b/Mockly.Specs/HttpMockSpecs.cs
@@ -3173,4 +3173,271 @@ public class HttpMockSpecs
         }
     }
 
+    public class QueryParameterMatching
+    {
+        [Fact]
+        public async Task Matches_a_query_parameter_regardless_of_order()
+        {
+            // Arrange
+            var mock = new HttpMock();
+
+            mock.ForGet()
+                .WithPath("/api/search")
+                .WithQueryParam("q", "mockly")
+                .RespondsWithStatus(HttpStatusCode.OK);
+
+            var client = mock.GetClient();
+
+            // Act
+            var response = await client.GetAsync("https://localhost/api/search?page=2&q=mockly");
+
+            // Assert
+            response.StatusCode.Should().Be(HttpStatusCode.OK);
+        }
+
+        [Fact]
+        public async Task Matches_a_query_parameter_when_unrelated_parameters_are_present()
+        {
+            // Arrange
+            var mock = new HttpMock();
+
+            mock.ForGet()
+                .WithPath("/api/search")
+                .WithQueryParam("q", "mockly")
+                .RespondsWithStatus(HttpStatusCode.OK);
+
+            var client = mock.GetClient();
+
+            // Act
+            var response = await client.GetAsync("https://localhost/api/search?q=mockly&sort=desc&page=3");
+
+            // Assert
+            response.StatusCode.Should().Be(HttpStatusCode.OK);
+        }
+
+        [Fact]
+        public async Task Matches_a_query_parameter_value_using_a_wildcard()
+        {
+            // Arrange
+            var mock = new HttpMock();
+
+            mock.ForGet()
+                .WithPath("/api/search")
+                .WithQueryParam("q", "moc*")
+                .RespondsWithStatus(HttpStatusCode.OK);
+
+            var client = mock.GetClient();
+
+            // Act
+            var response = await client.GetAsync("https://localhost/api/search?q=mockly");
+
+            // Assert
+            response.StatusCode.Should().Be(HttpStatusCode.OK);
+        }
+
+        [Fact]
+        public async Task Matches_a_query_parameter_by_presence_only()
+        {
+            // Arrange
+            var mock = new HttpMock();
+
+            mock.ForGet()
+                .WithPath("/api/search")
+                .WithQueryParam("q")
+                .RespondsWithStatus(HttpStatusCode.OK);
+
+            var client = mock.GetClient();
+
+            // Act
+            var response = await client.GetAsync("https://localhost/api/search?q=anything&page=1");
+
+            // Assert
+            response.StatusCode.Should().Be(HttpStatusCode.OK);
+        }
+
+        [Fact]
+        public async Task Does_not_match_when_the_query_parameter_is_absent()
+        {
+            // Arrange
+            var mock = new HttpMock();
+
+            mock.ForGet()
+                .WithPath("/api/search")
+                .WithQueryParam("q")
+                .RespondsWithStatus(HttpStatusCode.OK);
+
+            var client = mock.GetClient();
+
+            // Act
+            var act = () => client.GetAsync("https://localhost/api/search?page=1");
+
+            // Assert
+            await act.Should().ThrowAsync<UnexpectedRequestException>()
+                .WithMessage("*query parameter "q" is present*");
+        }
+
+        [Fact]
+        public async Task Does_not_match_when_the_query_parameter_value_differs()
+        {
+            // Arrange
+            var mock = new HttpMock();
+
+            mock.ForGet()
+                .WithPath("/api/search")
+                .WithQueryParam("q", "mockly")
+                .RespondsWithStatus(HttpStatusCode.OK);
+
+            var client = mock.GetClient();
+
+            // Act
+            var act = () => client.GetAsync("https://localhost/api/search?q=other");
+
+            // Assert
+            await act.Should().ThrowAsync<UnexpectedRequestException>()
+                .WithMessage("*query parameter "q" matches "mockly"*");
+        }
+
+        [Fact]
+        public async Task Matches_a_query_parameter_value_in_its_entirety()
+        {
+            // Arrange
+            var mock = new HttpMock();
+
+            mock.ForGet()
+                .WithPath("/api/search")
+                .WithQueryParam("q", "mockly")
+                .RespondsWithStatus(HttpStatusCode.OK);
+
+            var client = mock.GetClient();
+
+            // Act: a value that merely contains the pattern must not match
+            var act = () => client.GetAsync("https://localhost/api/search?q=mockly-extended");
+
+            // Assert
+            await act.Should().ThrowAsync<UnexpectedRequestException>()
+                .WithMessage("*query parameter "q" matches "mockly"*");
+        }
+
+        [Fact]
+        public async Task Can_combine_multiple_query_parameters()
+        {
+            // Arrange
+            var mock = new HttpMock();
+
+            mock.ForGet()
+                .WithPath("/api/search")
+                .WithQueryParam("q", "mockly")
+                .WithQueryParam("page", "2")
+                .RespondsWithStatus(HttpStatusCode.OK);
+
+            var client = mock.GetClient();
+
+            // Act
+            var response = await client.GetAsync("https://localhost/api/search?page=2&q=mockly");
+
+            // Assert
+            response.StatusCode.Should().Be(HttpStatusCode.OK);
+        }
+
+        [Fact]
+        public async Task Can_combine_a_query_parameter_with_a_full_query_pattern()
+        {
+            // Arrange
+            var mock = new HttpMock();
+
+            mock.ForGet()
+                .WithPath("/api/search")
+                .WithQuery("?q=mockly&page=2")
+                .WithQueryParam("page", "2")
+                .RespondsWithStatus(HttpStatusCode.OK);
+
+            var client = mock.GetClient();
+
+            // Act
+            var response = await client.GetAsync("https://localhost/api/search?q=mockly&page=2");
+
+            // Assert
+            response.StatusCode.Should().Be(HttpStatusCode.OK);
+        }
+    }
+
+    public class FormFieldMatching
+    {
+        [Fact]
+        public async Task Matches_a_form_field_regardless_of_order()
+        {
+            // Arrange
+            var mock = new HttpMock();
+
+            mock.ForPost()
+                .WithPath("/oauth/token")
+                .WithFormField("grant_type", "client_credentials")
+                .RespondsWithStatus(HttpStatusCode.OK);
+
+            var client = mock.GetClient();
+
+            var content = new FormUrlEncodedContent(
+            [
+                new KeyValuePair<string, string>("client_id", "abc"),
+                new KeyValuePair<string, string>("grant_type", "client_credentials"),
+            ]);
+
+            // Act
+            var response = await client.PostAsync("https://localhost/oauth/token", content);
+
+            // Assert
+            response.StatusCode.Should().Be(HttpStatusCode.OK);
+        }
+
+        [Fact]
+        public async Task Matches_a_form_field_value_using_a_wildcard()
+        {
+            // Arrange
+            var mock = new HttpMock();
+
+            mock.ForPost()
+                .WithPath("/oauth/token")
+                .WithFormField("scope", "read*")
+                .RespondsWithStatus(HttpStatusCode.OK);
+
+            var client = mock.GetClient();
+
+            var content = new FormUrlEncodedContent(
+            [
+                new KeyValuePair<string, string>("scope", "read write"),
+            ]);
+
+            // Act
+            var response = await client.PostAsync("https://localhost/oauth/token", content);
+
+            // Assert
+            response.StatusCode.Should().Be(HttpStatusCode.OK);
+        }
+
+        [Fact]
+        public async Task Does_not_match_when_the_form_field_value_differs()
+        {
+            // Arrange
+            var mock = new HttpMock();
+
+            mock.ForPost()
+                .WithPath("/oauth/token")
+                .WithFormField("grant_type", "client_credentials")
+                .RespondsWithStatus(HttpStatusCode.OK);
+
+            var client = mock.GetClient();
+
+            var content = new FormUrlEncodedContent(
+            [
+                new KeyValuePair<string, string>("grant_type", "password"),
+            ]);
+
+            // Act
+            var act = () => client.PostAsync("https://localhost/oauth/token", content);
+
+            // Assert
+            await act.Should().ThrowAsync<UnexpectedRequestException>()
+                .WithMessage("*form field "grant_type" matches "client_credentials"*");
+        }
+    }
 }

--- a/Mockly.Specs/HttpMockSpecs.cs
+++ b/Mockly.Specs/HttpMockSpecs.cs
@@ -3273,7 +3273,7 @@ public class HttpMockSpecs
 
             // Assert
             await act.Should().ThrowAsync<UnexpectedRequestException>()
-                .WithMessage("*query parameter "q" is present*");
+                .WithMessage("*query parameter \"q\" is present*");
         }
 
         [Fact]
@@ -3294,7 +3294,7 @@ public class HttpMockSpecs
 
             // Assert
             await act.Should().ThrowAsync<UnexpectedRequestException>()
-                .WithMessage("*query parameter "q" matches "mockly"*");
+                .WithMessage("*query parameter \"q\" matches \"mockly\"*");
         }
 
         [Fact]
@@ -3315,7 +3315,7 @@ public class HttpMockSpecs
 
             // Assert
             await act.Should().ThrowAsync<UnexpectedRequestException>()
-                .WithMessage("*query parameter "q" matches "mockly"*");
+                .WithMessage("*query parameter \"q\" matches \"mockly\"*");
         }
 
         [Fact]
@@ -3437,7 +3437,7 @@ public class HttpMockSpecs
 
             // Assert
             await act.Should().ThrowAsync<UnexpectedRequestException>()
-                .WithMessage("*form field "grant_type" matches "client_credentials"*");
+                .WithMessage("*form field \"grant_type\" matches \"client_credentials\"*");
         }
     }
 }

--- a/Mockly/Common/StringExtensions.cs
+++ b/Mockly/Common/StringExtensions.cs
@@ -1,3 +1,5 @@
+using System.Collections.Generic;
+using System.Net;
 using System.Text.RegularExpressions;
 
 #pragma warning disable CA1307
@@ -7,6 +9,65 @@ namespace Mockly.Common;
 
 internal static class StringExtensions
 {
+    /// <summary>
+    /// Parses an <c>application/x-www-form-urlencoded</c> string, such as a URI query string or a form body, into its
+    /// individual name/value pairs, decoding both names and values.
+    /// </summary>
+    /// <param name="input">The url-encoded string to parse. A leading <c>?</c> is ignored.</param>
+    /// <returns>The decoded name/value pairs in the order they appear in the input.</returns>
+    public static IEnumerable<KeyValuePair<string, string>> ParseUrlEncoded(this string? input)
+    {
+        if (string.IsNullOrEmpty(input))
+        {
+            yield break;
+        }
+
+        string data = input!.StartsWith("?", StringComparison.Ordinal) ? input.Substring(1) : input;
+
+        foreach (string pair in data.Split('&'))
+        {
+            if (pair.Length == 0)
+            {
+                continue;
+            }
+
+            int separatorIndex = pair.IndexOf('=');
+            if (separatorIndex < 0)
+            {
+                yield return new KeyValuePair<string, string>(WebUtility.UrlDecode(pair), string.Empty);
+            }
+            else
+            {
+                string name = WebUtility.UrlDecode(pair.Substring(0, separatorIndex));
+                string value = WebUtility.UrlDecode(pair.Substring(separatorIndex + 1));
+                yield return new KeyValuePair<string, string>(name, value);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Determines whether the specified text matches the given wildcard pattern in its entirety.
+    /// </summary>
+    /// <param name="text">The text to be evaluated.</param>
+    /// <param name="wildcardPattern">The wildcard pattern to match, allowing '?' for single character matches and '*' for multi-character matches.</param>
+    /// <remarks>
+    /// Unlike <see cref="MatchesWildcard"/>, the pattern is anchored, so the entire text must match the pattern rather
+    /// than merely containing a match.
+    /// </remarks>
+    public static bool MatchesWildcardExactly(this string text, string wildcardPattern)
+    {
+        if (text.Equals(wildcardPattern))
+        {
+            return true;
+        }
+
+        string regexPattern = "^" + Regex.Escape(wildcardPattern)
+            .Replace("\\*", ".*")
+            .Replace("\\?", ".") + "$";
+
+        return Regex.IsMatch(text, regexPattern, RegexOptions.IgnoreCase);
+    }
+
     /// <summary>
     /// Determines whether the specified text matches the given wildcard pattern.
     /// </summary>

--- a/Mockly/Common/StringExtensions.cs
+++ b/Mockly/Common/StringExtensions.cs
@@ -1,4 +1,3 @@
-using System.Collections.Generic;
 using System.Net;
 using System.Text.RegularExpressions;
 
@@ -9,133 +8,135 @@ namespace Mockly.Common;
 
 internal static class StringExtensions
 {
-    /// <summary>
-    /// Parses an <c>application/x-www-form-urlencoded</c> string, such as a URI query string or a form body, into its
-    /// individual name/value pairs, decoding both names and values.
-    /// </summary>
-    /// <param name="input">The url-encoded string to parse. A leading <c>?</c> is ignored.</param>
-    /// <returns>The decoded name/value pairs in the order they appear in the input.</returns>
-    public static IEnumerable<KeyValuePair<string, string>> ParseUrlEncoded(this string? input)
+    extension(string? input)
     {
-        if (string.IsNullOrEmpty(input))
+        /// <summary>
+        /// Parses an <c>application/x-www-form-urlencoded</c> string into its individual name/value pairs, decoding both names
+        /// and values. A leading <c>?</c> is ignored.
+        /// </summary>
+        /// <returns>The decoded name/value pairs in the order they appear in the input.</returns>
+        public IEnumerable<KeyValuePair<string, string>> ParseUrlEncoded()
         {
-            yield break;
-        }
-
-        string data = input!.StartsWith("?", StringComparison.Ordinal) ? input.Substring(1) : input;
-
-        foreach (string pair in data.Split('&'))
-        {
-            if (pair.Length == 0)
+            if (string.IsNullOrEmpty(input))
             {
-                continue;
+                yield break;
             }
 
-            int separatorIndex = pair.IndexOf('=');
-            if (separatorIndex < 0)
+            string data = input.StartsWith("?", StringComparison.Ordinal) ? input.Substring(1) : input;
+
+            foreach (string pair in data.Split('&'))
             {
-                yield return new KeyValuePair<string, string>(WebUtility.UrlDecode(pair), string.Empty);
+                if (pair.Length == 0)
+                {
+                    continue;
+                }
+
+                int separatorIndex = pair.IndexOf('=');
+                if (separatorIndex < 0)
+                {
+                    yield return new KeyValuePair<string, string>(WebUtility.UrlDecode(pair), string.Empty);
+                }
+                else
+                {
+                    string name = WebUtility.UrlDecode(pair.Substring(0, separatorIndex));
+                    string value = WebUtility.UrlDecode(pair.Substring(separatorIndex + 1));
+                    yield return new KeyValuePair<string, string>(name, value);
+                }
+            }
+        }
+    }
+
+    extension(string text)
+    {
+        /// <summary>
+        /// Determines whether the specified text matches the given wildcard pattern in its entirety.
+        /// </summary>
+        /// <param name="wildcardPattern">The wildcard pattern to match, allowing '?' for single character matches and '*' for multi-character matches.</param>
+        /// <remarks>
+        /// Unlike <see cref="MatchesWildcard"/>, the pattern is anchored, so the entire text must match the pattern rather
+        /// than merely containing a match.
+        /// </remarks>
+        public bool MatchesWildcardExactly(string wildcardPattern)
+        {
+            if (text.Equals(wildcardPattern))
+            {
+                return true;
+            }
+
+            string regexPattern = "^" + Regex.Escape(wildcardPattern)
+                .Replace("\\*", ".*")
+                .Replace("\\?", ".") + "$";
+
+            return Regex.IsMatch(text, regexPattern, RegexOptions.IgnoreCase);
+        }
+
+        /// <summary>
+        /// Determines whether the specified text matches the given wildcard pattern.
+        /// </summary>
+        /// <param name="wildcardPattern">The wildcard pattern to match, allowing '?' for single character matches and '*' for multi-character matches.</param>
+        public bool MatchesWildcard(string wildcardPattern)
+        {
+            if (text.Equals(wildcardPattern))
+            {
+                return true;
+            }
+
+            string regexPattern = Regex.Escape(wildcardPattern)
+                .Replace("\\*", ".*")
+                .Replace("\\?", ".");
+
+            return Regex.IsMatch(text, regexPattern, RegexOptions.IgnoreCase);
+        }
+
+        /// <summary>
+        /// Calculates how many characters two strings overlap while preserving order.
+        /// </summary>
+        /// <param name="other">The second string.</param>
+        /// <returns>
+        /// The length of the shorter string when all of its characters can be found in
+        /// the longer string in the same order; otherwise 0. For example, "abcdef" and
+        /// "abef" return 4 ("abef" is a subsequence of "abcdef"), "abcdef" and "acf"
+        /// return 3 ("acf" is a subsequence of "abcdef"), while "fedcba" and "abef"
+        /// return 0.
+        /// </returns>
+        public int CountOrderedOverlap(string other)
+        {
+            if (string.IsNullOrEmpty(text) || string.IsNullOrEmpty(other))
+            {
+                return 0;
+            }
+
+            // Determine which string is shorter to keep the logic symmetric with respect
+            // to the input order while still using the extension method syntax.
+            string longer;
+            string shorter;
+
+            if (text.Length >= other.Length)
+            {
+                longer = text;
+                shorter = other;
             }
             else
             {
-                string name = WebUtility.UrlDecode(pair.Substring(0, separatorIndex));
-                string value = WebUtility.UrlDecode(pair.Substring(separatorIndex + 1));
-                yield return new KeyValuePair<string, string>(name, value);
+                longer = other;
+                shorter = text;
             }
-        }
-    }
 
-    /// <summary>
-    /// Determines whether the specified text matches the given wildcard pattern in its entirety.
-    /// </summary>
-    /// <param name="text">The text to be evaluated.</param>
-    /// <param name="wildcardPattern">The wildcard pattern to match, allowing '?' for single character matches and '*' for multi-character matches.</param>
-    /// <remarks>
-    /// Unlike <see cref="MatchesWildcard"/>, the pattern is anchored, so the entire text must match the pattern rather
-    /// than merely containing a match.
-    /// </remarks>
-    public static bool MatchesWildcardExactly(this string text, string wildcardPattern)
-    {
-        if (text.Equals(wildcardPattern))
-        {
-            return true;
-        }
+            int j = 0;
 
-        string regexPattern = "^" + Regex.Escape(wildcardPattern)
-            .Replace("\\*", ".*")
-            .Replace("\\?", ".") + "$";
-
-        return Regex.IsMatch(text, regexPattern, RegexOptions.IgnoreCase);
-    }
-
-    /// <summary>
-    /// Determines whether the specified text matches the given wildcard pattern.
-    /// </summary>
-    /// <param name="text">The text to be evaluated.</param>
-    /// <param name="wildcardPattern">The wildcard pattern to match, allowing '?' for single character matches and '*' for multi-character matches.</param>
-    public static bool MatchesWildcard(this string text, string wildcardPattern)
-    {
-        if (text.Equals(wildcardPattern))
-        {
-            return true;
-        }
-
-        string regexPattern = Regex.Escape(wildcardPattern)
-            .Replace("\\*", ".*")
-            .Replace("\\?", ".");
-
-        return Regex.IsMatch(text, regexPattern, RegexOptions.IgnoreCase);
-    }
-
-    /// <summary>
-    /// Calculates how many characters two strings overlap while preserving order.
-    /// </summary>
-    /// <param name="text">The first string.</param>
-    /// <param name="other">The second string.</param>
-    /// <returns>
-    /// The length of the shorter string when all of its characters can be found in
-    /// the longer string in the same order; otherwise 0. For example, "abcdef" and
-    /// "abef" return 4 ("abef" is a subsequence of "abcdef"), "abcdef" and "acf"
-    /// return 3 ("acf" is a subsequence of "abcdef"), while "fedcba" and "abef"
-    /// return 0.
-    /// </returns>
-    public static int CountOrderedOverlap(this string text, string other)
-    {
-        if (string.IsNullOrEmpty(text) || string.IsNullOrEmpty(other))
-        {
-            return 0;
-        }
-
-        // Determine which string is shorter to keep the logic symmetric with respect
-        // to the input order while still using the extension method syntax.
-        string longer;
-        string shorter;
-
-        if (text.Length >= other.Length)
-        {
-            longer = text;
-            shorter = other;
-        }
-        else
-        {
-            longer = other;
-            shorter = text;
-        }
-
-        int j = 0;
-
-        // Walk the longer string once, advancing through the shorter string
-        // whenever characters match. If we can consume all characters of the
-        // shorter string in order, then it is a subsequence of the longer one.
-        for (int i = 0; i < longer.Length && j < shorter.Length; i++)
-        {
-            if (longer[i] == shorter[j])
+            // Walk the longer string once, advancing through the shorter string
+            // whenever characters match. If we can consume all characters of the
+            // shorter string in order, then it is a subsequence of the longer one.
+            for (int i = 0; i < longer.Length && j < shorter.Length; i++)
             {
-                j++;
+                if (longer[i] == shorter[j])
+                {
+                    j++;
+                }
             }
-        }
 
-        return j;
+            return j;
+        }
     }
 }
 

--- a/Mockly/Common/StringExtensions.cs
+++ b/Mockly/Common/StringExtensions.cs
@@ -22,7 +22,7 @@ internal static class StringExtensions
                 yield break;
             }
 
-            string data = input.StartsWith("?", StringComparison.Ordinal) ? input.Substring(1) : input;
+            string data = input!.StartsWith("?", StringComparison.Ordinal) ? input.Substring(1) : input;
 
             foreach (string pair in data.Split('&'))
             {

--- a/Mockly/RequestMockBuilder.cs
+++ b/Mockly/RequestMockBuilder.cs
@@ -127,6 +127,105 @@ public class RequestMockBuilder
     }
 
     /// <summary>
+    /// Configures the request mock to match requests whose query string contains a parameter with the specified name,
+    /// regardless of its value or position relative to other query parameters.
+    /// </summary>
+    /// <param name="name">The name of the query parameter that must be present.</param>
+    /// <remarks>
+    /// Unlike <see cref="WithQuery(string)"/>, this matcher is order-independent and ignores any additional query
+    /// parameters that may be present in the request.
+    /// </remarks>
+    public RequestMockBuilder WithQueryParam(string name)
+    {
+        if (name is null)
+        {
+            throw new ArgumentNullException(nameof(name));
+        }
+
+        return With(
+            request => QueryContainsParameter(request, name, valuePattern: null),
+            $"query parameter \"{name}\" is present");
+    }
+
+    /// <summary>
+    /// Configures the request mock to match requests whose query string contains a parameter with the specified name
+    /// and a value matching the specified wildcard pattern, regardless of its position relative to other query parameters.
+    /// </summary>
+    /// <param name="name">The name of the query parameter that must be present.</param>
+    /// <param name="valuePattern">
+    /// The wildcard pattern used to match the parameter value, where '?' represents any single character and '*' represents
+    /// any sequence of characters.
+    /// </param>
+    /// <remarks>
+    /// Unlike <see cref="WithQuery(string)"/>, this matcher is order-independent and ignores any additional query
+    /// parameters that may be present in the request.
+    /// </remarks>
+    public RequestMockBuilder WithQueryParam(string name, string valuePattern)
+    {
+        if (name is null)
+        {
+            throw new ArgumentNullException(nameof(name));
+        }
+
+        if (valuePattern is null)
+        {
+            throw new ArgumentNullException(nameof(valuePattern));
+        }
+
+        return With(
+            request => QueryContainsParameter(request, name, valuePattern),
+            $"query parameter \"{name}\" matches \"{valuePattern}\"");
+    }
+
+    /// <summary>
+    /// Configures the request mock to match requests whose <c>application/x-www-form-urlencoded</c> body contains a field
+    /// with the specified name and a value matching the specified wildcard pattern, regardless of its position relative to
+    /// other form fields.
+    /// </summary>
+    /// <param name="name">The name of the form field that must be present.</param>
+    /// <param name="valuePattern">
+    /// The wildcard pattern used to match the field value, where '?' represents any single character and '*' represents
+    /// any sequence of characters.
+    /// </param>
+    /// <remarks>
+    /// This matcher relies on the request body having been prefetched, which is enabled by default.
+    /// </remarks>
+    public RequestMockBuilder WithFormField(string name, string valuePattern)
+    {
+        if (name is null)
+        {
+            throw new ArgumentNullException(nameof(name));
+        }
+
+        if (valuePattern is null)
+        {
+            throw new ArgumentNullException(nameof(valuePattern));
+        }
+
+        return With(
+            request => BodyContainsFormField(request, name, valuePattern),
+            $"form field \"{name}\" matches \"{valuePattern}\"");
+    }
+
+    private static bool QueryContainsParameter(RequestInfo request, string name, string? valuePattern)
+    {
+        return request.Uri?.Query
+            .ParseUrlEncoded()
+            .Any(pair =>
+                string.Equals(pair.Key, name, StringComparison.OrdinalIgnoreCase) &&
+                (valuePattern is null || pair.Value.MatchesWildcardExactly(valuePattern))) ?? false;
+    }
+
+    private static bool BodyContainsFormField(RequestInfo request, string name, string valuePattern)
+    {
+        return request.Body
+            .ParseUrlEncoded()
+            .Any(pair =>
+                string.Equals(pair.Key, name, StringComparison.OrdinalIgnoreCase) &&
+                pair.Value.MatchesWildcardExactly(valuePattern));
+    }
+
+    /// <summary>
     /// Configures the request mock to match the request body content against a specified regular expression.
     /// </summary>
     /// <param name="regex">


### PR DESCRIPTION
Closes #118

## Summary

Adds structured, order-independent matchers for individual query-string parameters and for `application/x-www-form-urlencoded` request bodies, instead of only being able to match the entire query/body as one wildcard string. Each matcher is registered as a custom `Matcher` instance with a descriptive `displayText` for clear failure diagnostics.

## New API

```csharp
public RequestMockBuilder WithQueryParam(string name);                      // parameter present (any value)
public RequestMockBuilder WithQueryParam(string name, string valuePattern); // order-independent, supports wildcards
public RequestMockBuilder WithFormField(string name, string valuePattern);  // x-www-form-urlencoded body field
```

All additions are additive and backward-compatible. Approved API baselines were regenerated via `AcceptApiChanges.ps1` (`net8.0` and `net472`).

## Behaviour notes

- **Order-independent / extra params:** `WithQueryParam` and `WithFormField` ignore the position of the targeted parameter and any additional unrelated parameters present in the request. Because these register custom matchers, the special branch in `RequestMock.Matches` (which rejects a request that carries a query when no query pattern/custom matcher is configured) no longer rejects, so a `WithQueryParam` mock still matches when extra query params are present. This is pinned down by tests.
- **Values matched in full:** query/form values are compared with an *anchored* wildcard match (a new internal `MatchesWildcardExactly` helper), so `WithQueryParam("q", "mockly")` matches `q=mockly` but not `q=mockly-extended`. `*` and `?` wildcards are supported.
- **Decoding:** names and values are URL-decoded per component (handles `+` as space, percent-encoding, and values containing `=`).
- `WithFormField` relies on `PrefetchBody` (enabled by default).

## Tests

Added `QueryParameterMatching` and `FormFieldMatching` nested spec classes in `Mockly.Specs` covering: order-independence, presence-only, extra params present, wildcard values, full-value (anchored) matching, combination with `WithQuery`, combined query params, form-field match, and negative diagnostics. Full suite green on both `net8.0` (99) and `net472` (98).

## Follow-up

The companion FluentAssertions.Mockly assertion methods (`WithQueryParam` / `WithFormField` on `ContainedRequestAssertions`) described in #118 live in the separate **dennisdoomen/fluentassertions.mockly** repository and require a separate PR there. They are intentionally **not** part of this PR.