### PR TITLE
Add async responder overloads and CancellationToken flow

### DIFF
--- a/Mockly.ApiVerificationTests/ApprovedApi/net472.verified.txt
+++ b/Mockly.ApiVerificationTests/ApprovedApi/net472.verified.txt
@@ -113,6 +113,8 @@ namespace Mockly
         public Mockly.RequestMockBuilder ForHttp() { }
         public Mockly.RequestMockBuilder ForHttps() { }
         public Mockly.RequestMockResponseBuilder RespondsWith(System.Func<Mockly.RequestInfo, System.Net.Http.HttpResponseMessage> responder) { }
+        public Mockly.RequestMockResponseBuilder RespondsWith(System.Func<Mockly.RequestInfo, System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage>> responder) { }
+        public Mockly.RequestMockResponseBuilder RespondsWith(System.Func<Mockly.RequestInfo, System.Threading.CancellationToken, System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage>> responder) { }
         public Mockly.RequestMockResponseBuilder RespondsWith(System.Net.Http.HttpContent content) { }
         public Mockly.RequestMockResponseBuilder RespondsWith(System.Net.HttpStatusCode statusCode, System.Net.Http.HttpContent content) { }
         public Mockly.RequestMockResponseBuilder RespondsWithBytes(byte[] content, string contentType) { }

--- a/Mockly.ApiVerificationTests/ApprovedApi/net8.0.verified.txt
+++ b/Mockly.ApiVerificationTests/ApprovedApi/net8.0.verified.txt
@@ -116,6 +116,8 @@ namespace Mockly
         public Mockly.RequestMockBuilder ForHttp() { }
         public Mockly.RequestMockBuilder ForHttps() { }
         public Mockly.RequestMockResponseBuilder RespondsWith(System.Func<Mockly.RequestInfo, System.Net.Http.HttpResponseMessage> responder) { }
+        public Mockly.RequestMockResponseBuilder RespondsWith(System.Func<Mockly.RequestInfo, System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage>> responder) { }
+        public Mockly.RequestMockResponseBuilder RespondsWith(System.Func<Mockly.RequestInfo, System.Threading.CancellationToken, System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage>> responder) { }
         public Mockly.RequestMockResponseBuilder RespondsWith(System.Net.Http.HttpContent content) { }
         public Mockly.RequestMockResponseBuilder RespondsWith(System.Net.HttpStatusCode statusCode, System.Net.Http.HttpContent content) { }
         public Mockly.RequestMockResponseBuilder RespondsWithBytes(byte[] content, string contentType) { }

--- a/Mockly.Specs/HttpMockSpecs.cs
+++ b/Mockly.Specs/HttpMockSpecs.cs
@@ -7,10 +7,10 @@ using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Text;
 using System.Text.Json;
+using System.Threading;
 #if NET8_0_OR_GREATER
 using System.Collections.Concurrent;
 using System.Net.Http.Json;
-using System.Threading;
 #endif
 using System.Threading.Tasks;
 using FluentAssertions;
@@ -1677,7 +1677,7 @@ public class HttpMockSpecs
 
             mock.ForGet()
                 .WithPath("/api/custom")
-                .RespondsWith(_ => throw new InvalidOperationException());
+                .RespondsWith((Func<RequestInfo, HttpResponseMessage>)(_ => throw new InvalidOperationException()));
 
             // Build step removed;
             var client = mock.GetClient();
@@ -1825,6 +1825,297 @@ public class HttpMockSpecs
                     }
                 }
             });
+        }
+    }
+
+    public class WhenUsingAsyncResponders
+    {
+        [Fact]
+        public async Task An_async_responder_is_awaited()
+        {
+            // Arrange
+            var mock = new HttpMock();
+
+            mock.ForGet()
+                .WithPath("/api/async")
+                .RespondsWith(async _ =>
+                {
+                    await Task.Yield();
+                    return new HttpResponseMessage(HttpStatusCode.Accepted)
+                    {
+                        Content = new StringContent("async body")
+                    };
+                });
+
+            var client = mock.GetClient();
+
+            // Act
+            var response = await client.GetAsync("https://localhost/api/async");
+            var content = await response.Content.ReadAsStringAsync();
+
+            // Assert
+            response.StatusCode.Should().Be(HttpStatusCode.Accepted);
+            content.Should().Be("async body");
+        }
+
+        [Fact]
+        public async Task An_async_responder_with_a_cancellation_token_is_awaited()
+        {
+            // Arrange
+            var mock = new HttpMock();
+
+            mock.ForGet()
+                .WithPath("/api/async-ct")
+                .RespondsWith(async (_, _) =>
+                {
+                    await Task.Yield();
+                    return new HttpResponseMessage(HttpStatusCode.Created);
+                });
+
+            var client = mock.GetClient();
+
+            // Act
+            var response = await client.GetAsync("https://localhost/api/async-ct");
+
+            // Assert
+            response.StatusCode.Should().Be(HttpStatusCode.Created);
+        }
+
+        [Fact]
+        public async Task The_cancellation_token_is_passed_to_the_async_responder()
+        {
+            // Arrange
+            var mock = new HttpMock();
+            CancellationToken observedToken = default;
+
+            mock.ForGet()
+                .WithPath("/api/observe")
+                .RespondsWith((_, ct) =>
+                {
+                    observedToken = ct;
+                    return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK));
+                });
+
+            var client = mock.GetClient();
+
+            // Act
+            await client.GetAsync("https://localhost/api/observe");
+
+            // Assert
+            observedToken.CanBeCanceled.Should().BeTrue();
+        }
+
+        [Fact]
+        public async Task A_cancelled_token_is_observed_by_the_async_responder()
+        {
+            // Arrange
+            var mock = new HttpMock();
+            using var cts = new CancellationTokenSource();
+            var wasCancelled = false;
+
+            mock.ForGet()
+                .WithPath("/api/cancel")
+                .RespondsWith(async (_, ct) =>
+                {
+#if NET8_0_OR_GREATER
+                    await cts.CancelAsync();
+#else
+                    cts.Cancel();
+#endif
+                    try
+                    {
+                        await Task.Delay(Timeout.Infinite, ct);
+                    }
+                    catch (OperationCanceledException)
+                    {
+                        wasCancelled = true;
+                        throw;
+                    }
+
+                    return new HttpResponseMessage(HttpStatusCode.OK);
+                });
+
+            var client = mock.GetClient();
+
+            // Act
+            Func<Task> act = () => client.GetAsync("https://localhost/api/cancel", cts.Token);
+
+            // Assert
+            await act.Should().ThrowAsync<OperationCanceledException>();
+            wasCancelled.Should().BeTrue();
+        }
+
+        [Fact]
+        public async Task An_async_responder_works_with_invocation_limits()
+        {
+            // Arrange
+            var mock = new HttpMock();
+            var invocations = 0;
+
+            mock.ForGet()
+                .WithPath("/api/limited")
+                .RespondsWith(_ =>
+                {
+                    Interlocked.Increment(ref invocations);
+                    return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK));
+                })
+                .Once();
+
+            var client = mock.GetClient();
+
+            // Act
+            await client.GetAsync("https://localhost/api/limited");
+
+            // Assert
+            invocations.Should().Be(1);
+            mock.AllMocksInvoked.Should().BeTrue();
+        }
+
+        [Fact]
+        public async Task An_async_responder_collects_requests()
+        {
+            // Arrange
+            var mock = new HttpMock();
+            var collected = new RequestCollection();
+
+            mock.ForPost()
+                .WithPath("/api/collect")
+                .CollectingRequestsIn(collected)
+                .RespondsWith(_ => Task.FromResult(new HttpResponseMessage(HttpStatusCode.Accepted)));
+
+            var client = mock.GetClient();
+
+            // Act
+            await client.PostAsync("https://localhost/api/collect", new StringContent("payload"));
+
+            // Assert
+            collected.Should().ContainSingle();
+        }
+
+        [Fact]
+        public async Task An_exception_from_an_async_responder_results_in_an_internal_server_error()
+        {
+            // Arrange
+            var mock = new HttpMock();
+
+            mock.ForGet()
+                .WithPath("/api/async-throw")
+                .RespondsWith(_ => Task.FromException<HttpResponseMessage>(new InvalidOperationException()));
+
+            var client = mock.GetClient();
+
+            // Act
+            var response = await client.GetAsync("https://localhost/api/async-throw");
+
+            // Assert
+            response.StatusCode.Should().Be(HttpStatusCode.InternalServerError);
+            response.ReasonPhrase.Should().Contain("InvalidOperationException");
+        }
+
+        [Fact]
+        public async Task An_existing_synchronous_responder_still_works()
+        {
+            // Arrange
+            var mock = new HttpMock();
+
+            mock.ForGet()
+                .WithPath("/api/sync")
+                .RespondsWith(_ => new HttpResponseMessage(HttpStatusCode.Accepted)
+                {
+                    Content = new StringContent("sync body")
+                });
+
+            var client = mock.GetClient();
+
+            // Act
+            var response = await client.GetAsync("https://localhost/api/sync");
+            var content = await response.Content.ReadAsStringAsync();
+
+            // Assert
+            response.StatusCode.Should().Be(HttpStatusCode.Accepted);
+            content.Should().Be("sync body");
+        }
+
+        [Fact]
+        public async Task An_async_responder_receives_request_info()
+        {
+            // Arrange
+            var mock = new HttpMock();
+            RequestInfo capturedInfo = null;
+
+            mock.ForPost()
+                .WithPath("/api/info")
+                .RespondsWith(async request =>
+                {
+                    capturedInfo = request;
+                    await Task.Yield();
+                    return new HttpResponseMessage(HttpStatusCode.OK);
+                });
+
+            var client = mock.GetClient();
+
+            // Act
+            await client.PostAsync("https://localhost/api/info", new StringContent("hello", Encoding.UTF8, "text/plain"));
+
+            // Assert
+            capturedInfo.Should().NotBeNull();
+            capturedInfo.Method.Should().Be(HttpMethod.Post);
+            capturedInfo.Uri.AbsolutePath.Should().Be("/api/info");
+            capturedInfo.Body.Should().Be("hello");
+        }
+
+        [Fact]
+        public async Task An_async_responder_works_with_multiple_invocations()
+        {
+            // Arrange
+            var mock = new HttpMock();
+            var counter = 0;
+
+            mock.ForGet()
+                .WithPath("/api/multi")
+                .RespondsWith(_ =>
+                {
+                    Interlocked.Increment(ref counter);
+                    return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK));
+                });
+
+            var client = mock.GetClient();
+
+            // Act
+            await client.GetAsync("https://localhost/api/multi");
+            await client.GetAsync("https://localhost/api/multi");
+            await client.GetAsync("https://localhost/api/multi");
+
+            // Assert
+            counter.Should().Be(3);
+        }
+
+        [Fact]
+        public void Null_async_responder_throws_argument_null_exception()
+        {
+            // Arrange
+            var mock = new HttpMock();
+            var builder = mock.ForGet().WithPath("/api/null");
+
+            // Act
+            Action act = () => builder.RespondsWith((Func<RequestInfo, Task<HttpResponseMessage>>)null!);
+
+            // Assert
+            act.Should().Throw<ArgumentNullException>();
+        }
+
+        [Fact]
+        public void Null_async_responder_with_cancellation_token_throws_argument_null_exception()
+        {
+            // Arrange
+            var mock = new HttpMock();
+            var builder = mock.ForGet().WithPath("/api/null-ct");
+
+            // Act
+            Action act = () => builder.RespondsWith((Func<RequestInfo, CancellationToken, Task<HttpResponseMessage>>)null!);
+
+            // Assert
+            act.Should().Throw<ArgumentNullException>();
         }
     }
 

--- a/Mockly/HttpMock.cs
+++ b/Mockly/HttpMock.cs
@@ -255,13 +255,13 @@ public class HttpMock
         mocks.Add(mock);
     }
 
-    private async Task<HttpResponseMessage> HandleRequest(HttpRequestMessage httpRequest)
+    private async Task<HttpResponseMessage> HandleRequest(HttpRequestMessage httpRequest, CancellationToken cancellationToken)
     {
         RequestInfo request = await BuildRequestInfo(httpRequest);
 
         // Try to find a matching mock
         bool foundMatch = true;
-        CapturedRequest? capturedRequest = await TryFindMatchingMock(request);
+        CapturedRequest? capturedRequest = await TryFindMatchingMock(request, cancellationToken);
         if (capturedRequest == null)
         {
             capturedRequest = new CapturedRequest(request)
@@ -381,14 +381,14 @@ public class HttpMock
         return request;
     }
 
-    private async Task<CapturedRequest?> TryFindMatchingMock(RequestInfo request)
+    private async Task<CapturedRequest?> TryFindMatchingMock(RequestInfo request, CancellationToken cancellationToken)
     {
         RequestMock? matchingMock = await mocks.FirstOrDefaultAsync(m =>
             m.IsExhausted ? Task.FromResult(false) : m.Matches(request));
 
         if (matchingMock != null)
         {
-            return matchingMock.TrackRequest(request);
+            return await matchingMock.TrackRequestAsync(request, cancellationToken);
         }
 
         return null;
@@ -422,7 +422,7 @@ public class HttpMock
         protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request,
             CancellationToken cancellationToken)
         {
-            return await mock.HandleRequest(request);
+                return await mock.HandleRequest(request, cancellationToken);
         }
     }
 

--- a/Mockly/RequestMock.cs
+++ b/Mockly/RequestMock.cs
@@ -34,6 +34,13 @@ public class RequestMock
 
     public Func<RequestInfo, HttpResponseMessage> Responder { get; set; } = _ => new HttpResponseMessage();
 
+    /// <summary>
+    /// Gets the asynchronous responder used to produce a response for a matching request.
+    /// When set, this takes precedence over <see cref="Responder"/> and receives the
+    /// <see cref="CancellationToken"/> flowing from the HTTP pipeline.
+    /// </summary>
+    internal Func<RequestInfo, CancellationToken, Task<HttpResponseMessage>>? AsyncResponder { get; init; }
+
     public RequestCollection? RequestCollection { get; init; } = [];
 
     /// <summary>
@@ -254,6 +261,11 @@ public class RequestMock
     /// <summary>
     /// Handles the request and returns a response.
     /// </summary>
+    /// <remarks>
+    /// This synchronous overload only invokes the synchronous <see cref="Responder"/> and is preserved for
+    /// backwards compatibility. The HTTP pipeline uses <see cref="TrackRequestAsync"/> so that asynchronous
+    /// responders and cancellation are honored.
+    /// </remarks>
     public CapturedRequest TrackRequest(RequestInfo request)
     {
         Interlocked.Increment(ref invocationCount);
@@ -282,6 +294,58 @@ public class RequestMock
         RequestCollection?.Add(capturedRequest);
 
         return capturedRequest;
+    }
+
+    /// <summary>
+    /// Handles the request asynchronously and returns a response, awaiting the configured responder and
+    /// flowing the supplied <paramref name="cancellationToken"/> into it.
+    /// </summary>
+    /// <remarks>
+    /// Both synchronous and asynchronous responders converge on this single asynchronous execution path.
+    /// </remarks>
+    internal async Task<CapturedRequest> TrackRequestAsync(RequestInfo request, CancellationToken cancellationToken)
+    {
+        Interlocked.Increment(ref invocationCount);
+
+        CapturedRequest capturedRequest = new(request)
+        {
+            Mock = this,
+            WasExpected = true,
+            Timestamp = DateTime.UtcNow
+        };
+
+        try
+        {
+            capturedRequest.Response = await InvokeResponderAsync(request, cancellationToken);
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+#pragma warning disable CA1031
+        catch (Exception e)
+#pragma warning restore CA1031
+        {
+            capturedRequest.Response = new HttpResponseMessage(HttpStatusCode.InternalServerError)
+            {
+                ReasonPhrase = $"{e.GetType().Name}:{e.Message}"
+            };
+        }
+
+        RequestCollection?.Add(capturedRequest);
+
+        return capturedRequest;
+    }
+
+    /// <summary>
+    /// Invokes the asynchronous responder when configured; otherwise adapts the synchronous
+    /// <see cref="Responder"/> onto the asynchronous path.
+    /// </summary>
+    private Task<HttpResponseMessage> InvokeResponderAsync(RequestInfo request, CancellationToken cancellationToken)
+    {
+        return AsyncResponder is not null
+            ? AsyncResponder(request, cancellationToken)
+            : Task.FromResult(Responder(request));
     }
 
     /// <summary>

--- a/Mockly/RequestMockBuilder.cs
+++ b/Mockly/RequestMockBuilder.cs
@@ -6,6 +6,8 @@ using System.Runtime.CompilerServices;
 using System.Text;
 using System.Text.Json;
 using System.Text.RegularExpressions;
+using System.Threading;
+using System.Threading.Tasks;
 using Mockly.Common;
 
 #if NET472_OR_GREATER
@@ -1066,6 +1068,51 @@ public class RequestMockBuilder
             CustomMatchers = customMatchers,
             RequestCollection = requestCollection,
             Responder = responder
+        };
+
+        mockBuilder.AddMock(mock);
+        return new RequestMockResponseBuilder(mock);
+    }
+
+    /// <summary>
+    /// Responds using a custom asynchronous responder function that is awaited when producing the response.
+    /// </summary>
+    /// <param name="responder">An asynchronous function that produces the response for a matching request.</param>
+    public RequestMockResponseBuilder RespondsWith(Func<RequestInfo, Task<HttpResponseMessage>> responder)
+    {
+        if (responder is null)
+        {
+            throw new ArgumentNullException(nameof(responder));
+        }
+
+        return RespondsWith((request, _) => responder(request));
+    }
+
+    /// <summary>
+    /// Responds using a custom asynchronous responder function that is awaited when producing the response and
+    /// receives the <see cref="CancellationToken"/> flowing from the HTTP pipeline.
+    /// </summary>
+    /// <param name="responder">
+    /// An asynchronous function that produces the response for a matching request, observing the supplied
+    /// <see cref="CancellationToken"/>.
+    /// </param>
+    public RequestMockResponseBuilder RespondsWith(Func<RequestInfo, CancellationToken, Task<HttpResponseMessage>> responder)
+    {
+        if (responder is null)
+        {
+            throw new ArgumentNullException(nameof(responder));
+        }
+
+        var mock = new RequestMock
+        {
+            Method = Method,
+            PathPattern = pathPattern,
+            QueryPattern = queryPattern,
+            Scheme = scheme,
+            HostPattern = hostPattern,
+            CustomMatchers = customMatchers,
+            RequestCollection = requestCollection,
+            AsyncResponder = responder
         };
 
         mockBuilder.AddMock(mock);


### PR DESCRIPTION
Closes #120

## Summary

Adds asynchronous responder support to Mockly and flows the previously-dropped `CancellationToken` through the mock pipeline. This is the **foundation of an async-pipeline stack** — issues #117 (latency) and #116 (simulated failures) will stack on top of this branch and build on the single async execution path introduced here.

## What changed

- **One async execution path.** `RequestMock` gains an internal async responder (`Func<RequestInfo, CancellationToken, Task<HttpResponseMessage>>`). The existing synchronous `Responder` is adapted onto this path so both sync and async responders converge in a new internal `TrackRequestAsync`.
- **CancellationToken is now honored.** The token flows from `MockHttpMessageHandler.SendAsync` → `HttpMock.HandleRequest` → `RequestMock.TrackRequestAsync` (it was previously ignored). `OperationCanceledException` propagates out of the pipeline instead of being swallowed into a 500.
- **Backward compatible.** The public synchronous `RequestMock.Responder` property and `RequestMock.TrackRequest(RequestInfo)` method are unchanged and still work.

## New public API

```csharp
RequestMockResponseBuilder RespondsWith(Func<RequestInfo, Task<HttpResponseMessage>> responder);
RequestMockResponseBuilder RespondsWith(Func<RequestInfo, CancellationToken, Task<HttpResponseMessage>> responder);
```

The approved API verification files (`Mockly.ApiVerificationTests/ApprovedApi/*.verified.txt`) were regenerated via `AcceptApiChanges.ps1` and committed.

## Tests

New `WhenUsingAsyncResponders` spec class covers: async responder is awaited; async + `CancellationToken` overload is awaited; the token is passed to the responder; a cancelled token is observed and propagates; async responders work with invocation limits and request collection; exceptions surface as 500; and existing synchronous responders still work.

## Compatibility note

Overloading `RespondsWith` on the delegate return type makes a *throw-only* lambda (`RespondsWith(_ => throw ...)`) ambiguous, requiring an explicit delegate cast. One existing test was updated accordingly. Lambdas with an actual return value remain unambiguous.

## Verification

- `dotnet test` green for both `net8.0` (95 passed) and `net472` (94 passed).
- API verification tests green after accepting the additive changes.

## Stacking

#117 and #116 will stack on this branch and layer latency/failure simulation onto the async responder pipeline. Opened as **draft** for maintainer review — do not merge yet.