### PR TITLE
Add sequenced responses for repeated request matches

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -150,6 +150,12 @@ resharper_redundant_if_else_block_highlighting = none
 # If we use explicit property names in anonymous types, we do that on purpose.
 resharper_redundant_anonymous_type_property_name_highlighting = none
 
+# Public API methods in a library may only be called from external consumers not visible to InspectCode's global analysis.
+resharper_member_can_be_private_global_highlighting = none
+
+# Fluent builder methods intentionally return 'this' to allow optional chaining; not using the return value is valid.
+resharper_unused_method_return_value_global_highlighting = none
+
 ####################################################################
 ## Roslyn Analyzers and Code Fixes
 ####################################################################
@@ -374,6 +380,10 @@ dotnet_diagnostic.sa1622.severity = suggestion
 # Purpose: The property's documentation summary text should begin with: 'Gets or sets'
 # Rationale: We don't want to force this
 dotnet_diagnostic.SA1623.severity = suggestion
+
+# Purpose: Property summary documentation should begin with standard text
+# Rationale: We don't want to force this
+dotnet_diagnostic.SA1624.severity = suggestion
 
 # Purpose: Documentation text should end with a period
 # Rationale: We don't want to force this

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,6 +41,10 @@ dotnet test --filter FullyQualifiedName~Mockly.Specs.HttpMockSpecs+BasicUsage
 - Avoid new dependencies; never commit secrets; guard against ReDoS in matchers. Add any new
   analyzer packages to `Directory.Build.props` conditioned on `net8.0` with `<PrivateAssets>all</PrivateAssets>`.
 
+### Tests
+- Tests should not use terms like "should" or "when". Instead, they should use a fact-based naming convention in snake casing.
+- Test method names must describe observable behavior in business terms and must never start with or include the name of the method under test or any other code element. For example: `Returns_credit_report_for_valid_nl_company` ✅; `GetCompanyCreditReport_returns_credit_report_for_valid_nl_company_id` ❌.
+
 ## Public API changes
 
 Public API changes need an `api-approved` issue first. When the approval tests in

--- a/Mockly.ApiVerificationTests/ApprovedApi/net472.verified.txt
+++ b/Mockly.ApiVerificationTests/ApprovedApi/net472.verified.txt
@@ -112,33 +112,33 @@ namespace Mockly
         public Mockly.RequestMockBuilder ForHost(string hostPattern) { }
         public Mockly.RequestMockBuilder ForHttp() { }
         public Mockly.RequestMockBuilder ForHttps() { }
-        public Mockly.RequestMockResponseBuilder RespondsWith(System.Func<Mockly.RequestInfo, System.Net.Http.HttpResponseMessage> responder) { }
-        public Mockly.RequestMockResponseBuilder RespondsWith(System.Func<Mockly.RequestInfo, System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage>> responder) { }
-        public Mockly.RequestMockResponseBuilder RespondsWith(System.Func<Mockly.RequestInfo, System.Threading.CancellationToken, System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage>> responder) { }
-        public Mockly.RequestMockResponseBuilder RespondsWith(System.Net.Http.HttpContent content) { }
-        public Mockly.RequestMockResponseBuilder RespondsWith(System.Net.HttpStatusCode statusCode, System.Net.Http.HttpContent content) { }
-        public Mockly.RequestMockResponseBuilder RespondsWithBytes(byte[] content, string contentType) { }
-        public Mockly.RequestMockResponseBuilder RespondsWithContent(string content) { }
-        public Mockly.RequestMockResponseBuilder RespondsWithContent(System.Net.HttpStatusCode statusCode, string content, string contentType = "application/json") { }
-        public Mockly.RequestMockResponseBuilder RespondsWithEmptyContent(System.Net.HttpStatusCode statusCode = 204) { }
-        public Mockly.RequestMockResponseBuilder RespondsWithFile(string path, string? contentType = null) { }
-        public Mockly.RequestMockResponseBuilder RespondsWithJsonContent(object content) { }
-        public Mockly.RequestMockResponseBuilder RespondsWithJsonContent(System.Net.HttpStatusCode statusCode, object content) { }
-        public Mockly.RequestMockResponseBuilder RespondsWithJsonContent<T>(Mockly.IResponseBuilder<T> builder) { }
-        public Mockly.RequestMockResponseBuilder RespondsWithJsonContent<T>(System.Net.HttpStatusCode statusCode, Mockly.IResponseBuilder<T> builder) { }
-        public Mockly.RequestMockResponseBuilder RespondsWithODataResult(System.Collections.Generic.IEnumerable<object> value) { }
-        public Mockly.RequestMockResponseBuilder RespondsWithODataResult(object value) { }
-        public Mockly.RequestMockResponseBuilder RespondsWithODataResult(System.Net.HttpStatusCode statusCode, System.Collections.Generic.IEnumerable<object> value) { }
-        public Mockly.RequestMockResponseBuilder RespondsWithODataResult(System.Net.HttpStatusCode statusCode, object value) { }
-        public Mockly.RequestMockResponseBuilder RespondsWithODataResult(System.Net.HttpStatusCode statusCode, System.Collections.Generic.IEnumerable<object> value, string odataContext) { }
-        public Mockly.RequestMockResponseBuilder RespondsWithODataResult<T>(Mockly.IResponseBuilder<T> builder) { }
-        public Mockly.RequestMockResponseBuilder RespondsWithODataResult<T>(System.Collections.Generic.IEnumerable<Mockly.IResponseBuilder<T>> builders) { }
-        public Mockly.RequestMockResponseBuilder RespondsWithODataResult<T>(System.Net.HttpStatusCode statusCode, Mockly.IResponseBuilder<T> builder) { }
-        public Mockly.RequestMockResponseBuilder RespondsWithODataResult<T>(System.Net.HttpStatusCode statusCode, System.Collections.Generic.IEnumerable<Mockly.IResponseBuilder<T>> builders) { }
-        public Mockly.RequestMockResponseBuilder RespondsWithODataResult<T>(System.Net.HttpStatusCode statusCode, System.Collections.Generic.IEnumerable<Mockly.IResponseBuilder<T>> builders, string odataContext) { }
-        public Mockly.RequestMockResponseBuilder RespondsWithProblemDetails(System.Net.HttpStatusCode statusCode, string? title = null, string? detail = null, string? type = null, string? instance = null, System.Collections.Generic.IDictionary<string, object?>? extensions = null) { }
-        public Mockly.RequestMockResponseBuilder RespondsWithStatus(System.Net.HttpStatusCode statusCode) { }
-        public Mockly.RequestMockResponseBuilder RespondsWithStream(System.IO.Stream stream, string contentType) { }
+        public Mockly.SequencedResponseBuilder RespondsWith(System.Func<Mockly.RequestInfo, System.Net.Http.HttpResponseMessage> responder) { }
+        public Mockly.SequencedResponseBuilder RespondsWith(System.Func<Mockly.RequestInfo, System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage>> responder) { }
+        public Mockly.SequencedResponseBuilder RespondsWith(System.Func<Mockly.RequestInfo, System.Threading.CancellationToken, System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage>> responder) { }
+        public Mockly.SequencedResponseBuilder RespondsWith(System.Net.Http.HttpContent content) { }
+        public Mockly.SequencedResponseBuilder RespondsWith(System.Net.HttpStatusCode statusCode, System.Net.Http.HttpContent content) { }
+        public Mockly.SequencedResponseBuilder RespondsWithBytes(byte[] content, string contentType) { }
+        public Mockly.SequencedResponseBuilder RespondsWithContent(string content) { }
+        public Mockly.SequencedResponseBuilder RespondsWithContent(System.Net.HttpStatusCode statusCode, string content, string contentType = "application/json") { }
+        public Mockly.SequencedResponseBuilder RespondsWithEmptyContent(System.Net.HttpStatusCode statusCode = 204) { }
+        public Mockly.SequencedResponseBuilder RespondsWithFile(string path, string? contentType = null) { }
+        public Mockly.SequencedResponseBuilder RespondsWithJsonContent(object content) { }
+        public Mockly.SequencedResponseBuilder RespondsWithJsonContent(System.Net.HttpStatusCode statusCode, object content) { }
+        public Mockly.SequencedResponseBuilder RespondsWithJsonContent<T>(Mockly.IResponseBuilder<T> builder) { }
+        public Mockly.SequencedResponseBuilder RespondsWithJsonContent<T>(System.Net.HttpStatusCode statusCode, Mockly.IResponseBuilder<T> builder) { }
+        public Mockly.SequencedResponseBuilder RespondsWithODataResult(System.Collections.Generic.IEnumerable<object> value) { }
+        public Mockly.SequencedResponseBuilder RespondsWithODataResult(object value) { }
+        public Mockly.SequencedResponseBuilder RespondsWithODataResult(System.Net.HttpStatusCode statusCode, System.Collections.Generic.IEnumerable<object> value) { }
+        public Mockly.SequencedResponseBuilder RespondsWithODataResult(System.Net.HttpStatusCode statusCode, object value) { }
+        public Mockly.SequencedResponseBuilder RespondsWithODataResult(System.Net.HttpStatusCode statusCode, System.Collections.Generic.IEnumerable<object> value, string odataContext) { }
+        public Mockly.SequencedResponseBuilder RespondsWithODataResult<T>(Mockly.IResponseBuilder<T> builder) { }
+        public Mockly.SequencedResponseBuilder RespondsWithODataResult<T>(System.Collections.Generic.IEnumerable<Mockly.IResponseBuilder<T>> builders) { }
+        public Mockly.SequencedResponseBuilder RespondsWithODataResult<T>(System.Net.HttpStatusCode statusCode, Mockly.IResponseBuilder<T> builder) { }
+        public Mockly.SequencedResponseBuilder RespondsWithODataResult<T>(System.Net.HttpStatusCode statusCode, System.Collections.Generic.IEnumerable<Mockly.IResponseBuilder<T>> builders) { }
+        public Mockly.SequencedResponseBuilder RespondsWithODataResult<T>(System.Net.HttpStatusCode statusCode, System.Collections.Generic.IEnumerable<Mockly.IResponseBuilder<T>> builders, string odataContext) { }
+        public Mockly.SequencedResponseBuilder RespondsWithProblemDetails(System.Net.HttpStatusCode statusCode, string? title = null, string? detail = null, string? type = null, string? instance = null, System.Collections.Generic.IDictionary<string, object?>? extensions = null) { }
+        public Mockly.SequencedResponseBuilder RespondsWithStatus(System.Net.HttpStatusCode statusCode) { }
+        public Mockly.SequencedResponseBuilder RespondsWithStream(System.IO.Stream stream, string contentType) { }
         public Mockly.RequestMockBuilder Using(System.Text.Json.JsonSerializerOptions options) { }
         public Mockly.RequestMockBuilder With(System.Func<Mockly.RequestInfo, System.Threading.Tasks.Task<bool>> matcher, [System.Runtime.CompilerServices.CallerArgumentExpression("matcher")] string? matcherText = null) { }
         public Mockly.RequestMockBuilder With(System.Func<Mockly.RequestInfo, bool> matcher, [System.Runtime.CompilerServices.CallerArgumentExpression("matcher")] string? matcherText = null) { }
@@ -165,6 +165,37 @@ namespace Mockly
         public Mockly.RequestMockResponseBuilder Twice() { }
         public Mockly.RequestMockResponseBuilder WithHeader(string name, string value) { }
         public Mockly.RequestMockResponseBuilder WithHeader(string name, params string[] values) { }
+    }
+    public class SequencedResponseBuilder : Mockly.RequestMockResponseBuilder
+    {
+        public new Mockly.SequencedResponseBuilder Once() { }
+        public Mockly.SequencedResponseBuilder ThenRespondsWith(System.Func<Mockly.RequestInfo, System.Net.Http.HttpResponseMessage> responder) { }
+        public Mockly.SequencedResponseBuilder ThenRespondsWith(System.Func<Mockly.RequestInfo, System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage>> responder) { }
+        public Mockly.SequencedResponseBuilder ThenRespondsWith(System.Func<Mockly.RequestInfo, System.Threading.CancellationToken, System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage>> responder) { }
+        public Mockly.SequencedResponseBuilder ThenRespondsWith(System.Net.Http.HttpContent content) { }
+        public Mockly.SequencedResponseBuilder ThenRespondsWith(System.Net.HttpStatusCode statusCode, System.Net.Http.HttpContent content) { }
+        public Mockly.SequencedResponseBuilder ThenRespondsWithContent(string content) { }
+        public Mockly.SequencedResponseBuilder ThenRespondsWithContent(System.Net.HttpStatusCode statusCode, string content, string contentType = "application/json") { }
+        public Mockly.SequencedResponseBuilder ThenRespondsWithEmptyContent(System.Net.HttpStatusCode statusCode = 204) { }
+        public Mockly.SequencedResponseBuilder ThenRespondsWithJsonContent(object content) { }
+        public Mockly.SequencedResponseBuilder ThenRespondsWithJsonContent(System.Net.HttpStatusCode statusCode, object content) { }
+        public Mockly.SequencedResponseBuilder ThenRespondsWithJsonContent<T>(Mockly.IResponseBuilder<T> builder) { }
+        public Mockly.SequencedResponseBuilder ThenRespondsWithJsonContent<T>(System.Net.HttpStatusCode statusCode, Mockly.IResponseBuilder<T> builder) { }
+        public Mockly.SequencedResponseBuilder ThenRespondsWithODataResult(System.Collections.Generic.IEnumerable<object> value) { }
+        public Mockly.SequencedResponseBuilder ThenRespondsWithODataResult(object value) { }
+        public Mockly.SequencedResponseBuilder ThenRespondsWithODataResult(System.Net.HttpStatusCode statusCode, System.Collections.Generic.IEnumerable<object> value) { }
+        public Mockly.SequencedResponseBuilder ThenRespondsWithODataResult(System.Net.HttpStatusCode statusCode, object value) { }
+        public Mockly.SequencedResponseBuilder ThenRespondsWithODataResult(System.Net.HttpStatusCode statusCode, System.Collections.Generic.IEnumerable<object> value, string odataContext) { }
+        public Mockly.SequencedResponseBuilder ThenRespondsWithODataResult<T>(Mockly.IResponseBuilder<T> builder) { }
+        public Mockly.SequencedResponseBuilder ThenRespondsWithODataResult<T>(System.Collections.Generic.IEnumerable<Mockly.IResponseBuilder<T>> builders) { }
+        public Mockly.SequencedResponseBuilder ThenRespondsWithODataResult<T>(System.Net.HttpStatusCode statusCode, Mockly.IResponseBuilder<T> builder) { }
+        public Mockly.SequencedResponseBuilder ThenRespondsWithODataResult<T>(System.Net.HttpStatusCode statusCode, System.Collections.Generic.IEnumerable<Mockly.IResponseBuilder<T>> builders) { }
+        public Mockly.SequencedResponseBuilder ThenRespondsWithODataResult<T>(System.Net.HttpStatusCode statusCode, System.Collections.Generic.IEnumerable<Mockly.IResponseBuilder<T>> builders, string odataContext) { }
+        public Mockly.SequencedResponseBuilder ThenRespondsWithStatus(System.Net.HttpStatusCode statusCode) { }
+        public new Mockly.SequencedResponseBuilder Times(uint count) { }
+        public new Mockly.SequencedResponseBuilder Twice() { }
+        public new Mockly.SequencedResponseBuilder WithHeader(string name, string value) { }
+        public new Mockly.SequencedResponseBuilder WithHeader(string name, params string[] values) { }
     }
     public class UnexpectedRequestException : System.Exception
     {

--- a/Mockly.ApiVerificationTests/ApprovedApi/net8.0.verified.txt
+++ b/Mockly.ApiVerificationTests/ApprovedApi/net8.0.verified.txt
@@ -115,33 +115,33 @@ namespace Mockly
         public Mockly.RequestMockBuilder ForHost(string hostPattern) { }
         public Mockly.RequestMockBuilder ForHttp() { }
         public Mockly.RequestMockBuilder ForHttps() { }
-        public Mockly.RequestMockResponseBuilder RespondsWith(System.Func<Mockly.RequestInfo, System.Net.Http.HttpResponseMessage> responder) { }
-        public Mockly.RequestMockResponseBuilder RespondsWith(System.Func<Mockly.RequestInfo, System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage>> responder) { }
-        public Mockly.RequestMockResponseBuilder RespondsWith(System.Func<Mockly.RequestInfo, System.Threading.CancellationToken, System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage>> responder) { }
-        public Mockly.RequestMockResponseBuilder RespondsWith(System.Net.Http.HttpContent content) { }
-        public Mockly.RequestMockResponseBuilder RespondsWith(System.Net.HttpStatusCode statusCode, System.Net.Http.HttpContent content) { }
-        public Mockly.RequestMockResponseBuilder RespondsWithBytes(byte[] content, string contentType) { }
-        public Mockly.RequestMockResponseBuilder RespondsWithContent(string content) { }
-        public Mockly.RequestMockResponseBuilder RespondsWithContent(System.Net.HttpStatusCode statusCode, string content, string contentType = "application/json") { }
-        public Mockly.RequestMockResponseBuilder RespondsWithEmptyContent(System.Net.HttpStatusCode statusCode = 204) { }
-        public Mockly.RequestMockResponseBuilder RespondsWithFile(string path, string? contentType = null) { }
-        public Mockly.RequestMockResponseBuilder RespondsWithJsonContent(object content) { }
-        public Mockly.RequestMockResponseBuilder RespondsWithJsonContent(System.Net.HttpStatusCode statusCode, object content) { }
-        public Mockly.RequestMockResponseBuilder RespondsWithJsonContent<T>(Mockly.IResponseBuilder<T> builder) { }
-        public Mockly.RequestMockResponseBuilder RespondsWithJsonContent<T>(System.Net.HttpStatusCode statusCode, Mockly.IResponseBuilder<T> builder) { }
-        public Mockly.RequestMockResponseBuilder RespondsWithODataResult(System.Collections.Generic.IEnumerable<object> value) { }
-        public Mockly.RequestMockResponseBuilder RespondsWithODataResult(object value) { }
-        public Mockly.RequestMockResponseBuilder RespondsWithODataResult(System.Net.HttpStatusCode statusCode, System.Collections.Generic.IEnumerable<object> value) { }
-        public Mockly.RequestMockResponseBuilder RespondsWithODataResult(System.Net.HttpStatusCode statusCode, object value) { }
-        public Mockly.RequestMockResponseBuilder RespondsWithODataResult(System.Net.HttpStatusCode statusCode, System.Collections.Generic.IEnumerable<object> value, string odataContext) { }
-        public Mockly.RequestMockResponseBuilder RespondsWithODataResult<T>(Mockly.IResponseBuilder<T> builder) { }
-        public Mockly.RequestMockResponseBuilder RespondsWithODataResult<T>(System.Collections.Generic.IEnumerable<Mockly.IResponseBuilder<T>> builders) { }
-        public Mockly.RequestMockResponseBuilder RespondsWithODataResult<T>(System.Net.HttpStatusCode statusCode, Mockly.IResponseBuilder<T> builder) { }
-        public Mockly.RequestMockResponseBuilder RespondsWithODataResult<T>(System.Net.HttpStatusCode statusCode, System.Collections.Generic.IEnumerable<Mockly.IResponseBuilder<T>> builders) { }
-        public Mockly.RequestMockResponseBuilder RespondsWithODataResult<T>(System.Net.HttpStatusCode statusCode, System.Collections.Generic.IEnumerable<Mockly.IResponseBuilder<T>> builders, string odataContext) { }
-        public Mockly.RequestMockResponseBuilder RespondsWithProblemDetails(System.Net.HttpStatusCode statusCode, string? title = null, string? detail = null, string? type = null, string? instance = null, System.Collections.Generic.IDictionary<string, object?>? extensions = null) { }
-        public Mockly.RequestMockResponseBuilder RespondsWithStatus(System.Net.HttpStatusCode statusCode) { }
-        public Mockly.RequestMockResponseBuilder RespondsWithStream(System.IO.Stream stream, string contentType) { }
+        public Mockly.SequencedResponseBuilder RespondsWith(System.Func<Mockly.RequestInfo, System.Net.Http.HttpResponseMessage> responder) { }
+        public Mockly.SequencedResponseBuilder RespondsWith(System.Func<Mockly.RequestInfo, System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage>> responder) { }
+        public Mockly.SequencedResponseBuilder RespondsWith(System.Func<Mockly.RequestInfo, System.Threading.CancellationToken, System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage>> responder) { }
+        public Mockly.SequencedResponseBuilder RespondsWith(System.Net.Http.HttpContent content) { }
+        public Mockly.SequencedResponseBuilder RespondsWith(System.Net.HttpStatusCode statusCode, System.Net.Http.HttpContent content) { }
+        public Mockly.SequencedResponseBuilder RespondsWithBytes(byte[] content, string contentType) { }
+        public Mockly.SequencedResponseBuilder RespondsWithContent(string content) { }
+        public Mockly.SequencedResponseBuilder RespondsWithContent(System.Net.HttpStatusCode statusCode, string content, string contentType = "application/json") { }
+        public Mockly.SequencedResponseBuilder RespondsWithEmptyContent(System.Net.HttpStatusCode statusCode = 204) { }
+        public Mockly.SequencedResponseBuilder RespondsWithFile(string path, string? contentType = null) { }
+        public Mockly.SequencedResponseBuilder RespondsWithJsonContent(object content) { }
+        public Mockly.SequencedResponseBuilder RespondsWithJsonContent(System.Net.HttpStatusCode statusCode, object content) { }
+        public Mockly.SequencedResponseBuilder RespondsWithJsonContent<T>(Mockly.IResponseBuilder<T> builder) { }
+        public Mockly.SequencedResponseBuilder RespondsWithJsonContent<T>(System.Net.HttpStatusCode statusCode, Mockly.IResponseBuilder<T> builder) { }
+        public Mockly.SequencedResponseBuilder RespondsWithODataResult(System.Collections.Generic.IEnumerable<object> value) { }
+        public Mockly.SequencedResponseBuilder RespondsWithODataResult(object value) { }
+        public Mockly.SequencedResponseBuilder RespondsWithODataResult(System.Net.HttpStatusCode statusCode, System.Collections.Generic.IEnumerable<object> value) { }
+        public Mockly.SequencedResponseBuilder RespondsWithODataResult(System.Net.HttpStatusCode statusCode, object value) { }
+        public Mockly.SequencedResponseBuilder RespondsWithODataResult(System.Net.HttpStatusCode statusCode, System.Collections.Generic.IEnumerable<object> value, string odataContext) { }
+        public Mockly.SequencedResponseBuilder RespondsWithODataResult<T>(Mockly.IResponseBuilder<T> builder) { }
+        public Mockly.SequencedResponseBuilder RespondsWithODataResult<T>(System.Collections.Generic.IEnumerable<Mockly.IResponseBuilder<T>> builders) { }
+        public Mockly.SequencedResponseBuilder RespondsWithODataResult<T>(System.Net.HttpStatusCode statusCode, Mockly.IResponseBuilder<T> builder) { }
+        public Mockly.SequencedResponseBuilder RespondsWithODataResult<T>(System.Net.HttpStatusCode statusCode, System.Collections.Generic.IEnumerable<Mockly.IResponseBuilder<T>> builders) { }
+        public Mockly.SequencedResponseBuilder RespondsWithODataResult<T>(System.Net.HttpStatusCode statusCode, System.Collections.Generic.IEnumerable<Mockly.IResponseBuilder<T>> builders, string odataContext) { }
+        public Mockly.SequencedResponseBuilder RespondsWithProblemDetails(System.Net.HttpStatusCode statusCode, string? title = null, string? detail = null, string? type = null, string? instance = null, System.Collections.Generic.IDictionary<string, object?>? extensions = null) { }
+        public Mockly.SequencedResponseBuilder RespondsWithStatus(System.Net.HttpStatusCode statusCode) { }
+        public Mockly.SequencedResponseBuilder RespondsWithStream(System.IO.Stream stream, string contentType) { }
         public Mockly.RequestMockBuilder Using(System.Text.Json.JsonSerializerOptions options) { }
         public Mockly.RequestMockBuilder With(System.Func<Mockly.RequestInfo, System.Threading.Tasks.Task<bool>> matcher, [System.Runtime.CompilerServices.CallerArgumentExpression("matcher")] string? matcherText = null) { }
         public Mockly.RequestMockBuilder With(System.Func<Mockly.RequestInfo, bool> matcher, [System.Runtime.CompilerServices.CallerArgumentExpression("matcher")] string? matcherText = null) { }
@@ -168,6 +168,37 @@ namespace Mockly
         public Mockly.RequestMockResponseBuilder Twice() { }
         public Mockly.RequestMockResponseBuilder WithHeader(string name, string value) { }
         public Mockly.RequestMockResponseBuilder WithHeader(string name, params string[] values) { }
+    }
+    public class SequencedResponseBuilder : Mockly.RequestMockResponseBuilder
+    {
+        public new Mockly.SequencedResponseBuilder Once() { }
+        public Mockly.SequencedResponseBuilder ThenRespondsWith(System.Func<Mockly.RequestInfo, System.Net.Http.HttpResponseMessage> responder) { }
+        public Mockly.SequencedResponseBuilder ThenRespondsWith(System.Func<Mockly.RequestInfo, System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage>> responder) { }
+        public Mockly.SequencedResponseBuilder ThenRespondsWith(System.Func<Mockly.RequestInfo, System.Threading.CancellationToken, System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage>> responder) { }
+        public Mockly.SequencedResponseBuilder ThenRespondsWith(System.Net.Http.HttpContent content) { }
+        public Mockly.SequencedResponseBuilder ThenRespondsWith(System.Net.HttpStatusCode statusCode, System.Net.Http.HttpContent content) { }
+        public Mockly.SequencedResponseBuilder ThenRespondsWithContent(string content) { }
+        public Mockly.SequencedResponseBuilder ThenRespondsWithContent(System.Net.HttpStatusCode statusCode, string content, string contentType = "application/json") { }
+        public Mockly.SequencedResponseBuilder ThenRespondsWithEmptyContent(System.Net.HttpStatusCode statusCode = 204) { }
+        public Mockly.SequencedResponseBuilder ThenRespondsWithJsonContent(object content) { }
+        public Mockly.SequencedResponseBuilder ThenRespondsWithJsonContent(System.Net.HttpStatusCode statusCode, object content) { }
+        public Mockly.SequencedResponseBuilder ThenRespondsWithJsonContent<T>(Mockly.IResponseBuilder<T> builder) { }
+        public Mockly.SequencedResponseBuilder ThenRespondsWithJsonContent<T>(System.Net.HttpStatusCode statusCode, Mockly.IResponseBuilder<T> builder) { }
+        public Mockly.SequencedResponseBuilder ThenRespondsWithODataResult(System.Collections.Generic.IEnumerable<object> value) { }
+        public Mockly.SequencedResponseBuilder ThenRespondsWithODataResult(object value) { }
+        public Mockly.SequencedResponseBuilder ThenRespondsWithODataResult(System.Net.HttpStatusCode statusCode, System.Collections.Generic.IEnumerable<object> value) { }
+        public Mockly.SequencedResponseBuilder ThenRespondsWithODataResult(System.Net.HttpStatusCode statusCode, object value) { }
+        public Mockly.SequencedResponseBuilder ThenRespondsWithODataResult(System.Net.HttpStatusCode statusCode, System.Collections.Generic.IEnumerable<object> value, string odataContext) { }
+        public Mockly.SequencedResponseBuilder ThenRespondsWithODataResult<T>(Mockly.IResponseBuilder<T> builder) { }
+        public Mockly.SequencedResponseBuilder ThenRespondsWithODataResult<T>(System.Collections.Generic.IEnumerable<Mockly.IResponseBuilder<T>> builders) { }
+        public Mockly.SequencedResponseBuilder ThenRespondsWithODataResult<T>(System.Net.HttpStatusCode statusCode, Mockly.IResponseBuilder<T> builder) { }
+        public Mockly.SequencedResponseBuilder ThenRespondsWithODataResult<T>(System.Net.HttpStatusCode statusCode, System.Collections.Generic.IEnumerable<Mockly.IResponseBuilder<T>> builders) { }
+        public Mockly.SequencedResponseBuilder ThenRespondsWithODataResult<T>(System.Net.HttpStatusCode statusCode, System.Collections.Generic.IEnumerable<Mockly.IResponseBuilder<T>> builders, string odataContext) { }
+        public Mockly.SequencedResponseBuilder ThenRespondsWithStatus(System.Net.HttpStatusCode statusCode) { }
+        public new Mockly.SequencedResponseBuilder Times(uint count) { }
+        public new Mockly.SequencedResponseBuilder Twice() { }
+        public new Mockly.SequencedResponseBuilder WithHeader(string name, string value) { }
+        public new Mockly.SequencedResponseBuilder WithHeader(string name, params string[] values) { }
     }
     public class UnexpectedRequestException : System.Exception
     {

--- a/Mockly.Specs/HttpMockSpecs.cs
+++ b/Mockly.Specs/HttpMockSpecs.cs
@@ -2960,6 +2960,25 @@ public class HttpMockSpecs
         }
 
         [Fact]
+        public async Task Applies_headers_to_every_response_in_a_sequence()
+        {
+            // Arrange
+            var mock = new HttpMock();
+            mock.ForGet().WithPath("api/data")
+                .RespondsWithStatus(HttpStatusCode.Accepted)
+                .ThenRespondsWithStatus(HttpStatusCode.OK)
+                .WithHeader("X-Sequence", "yes");
+
+            // Act
+            var first = await mock.GetClient().GetAsync("https://localhost/api/data");
+            var second = await mock.GetClient().GetAsync("https://localhost/api/data");
+
+            // Assert
+            first.Headers.GetValues("X-Sequence").Should().ContainSingle().Which.Should().Be("yes");
+            second.Headers.GetValues("X-Sequence").Should().ContainSingle().Which.Should().Be("yes");
+        }
+
+        [Fact]
         public async Task The_last_configured_value_wins_when_a_header_is_set_twice()
         {
             // Arrange
@@ -3247,6 +3266,555 @@ public class HttpMockSpecs
 
             // Assert
             response.StatusCode.Should().Be(HttpStatusCode.OK);
+        }
+    }
+
+    public class SequencedResponses
+    {
+        [Fact]
+        public async Task The_sequence_advances_with_each_call()
+        {
+            // Arrange
+            var mock = new HttpMock();
+            mock.ForGet().WithPath("/resource")
+                .RespondsWithStatus(HttpStatusCode.ServiceUnavailable)
+                .ThenRespondsWithStatus(HttpStatusCode.ServiceUnavailable)
+                .ThenRespondsWithStatus(HttpStatusCode.OK);
+
+            var client = mock.GetClient();
+
+            // Act
+            var first = await client.GetAsync("https://localhost/resource");
+            var second = await client.GetAsync("https://localhost/resource");
+            var third = await client.GetAsync("https://localhost/resource");
+
+            // Assert
+            first.StatusCode.Should().Be(HttpStatusCode.ServiceUnavailable);
+            second.StatusCode.Should().Be(HttpStatusCode.ServiceUnavailable);
+            third.StatusCode.Should().Be(HttpStatusCode.OK);
+        }
+
+        [Fact]
+        public async Task The_last_response_repeats_once_the_sequence_is_exhausted()
+        {
+            // Arrange
+            var mock = new HttpMock();
+            mock.ForGet().WithPath("/resource")
+                .RespondsWithStatus(HttpStatusCode.InternalServerError)
+                .ThenRespondsWithStatus(HttpStatusCode.OK);
+
+            var client = mock.GetClient();
+
+            // Act
+            var first = await client.GetAsync("https://localhost/resource");
+            var second = await client.GetAsync("https://localhost/resource");
+            var third = await client.GetAsync("https://localhost/resource");
+
+            // Assert
+            first.StatusCode.Should().Be(HttpStatusCode.InternalServerError);
+            second.StatusCode.Should().Be(HttpStatusCode.OK);
+            third.StatusCode.Should().Be(HttpStatusCode.OK);
+        }
+
+        [Fact]
+        public async Task A_single_response_keeps_repeating()
+        {
+            // Arrange
+            var mock = new HttpMock();
+            mock.ForGet().WithPath("/resource").RespondsWithStatus(HttpStatusCode.OK);
+
+            var client = mock.GetClient();
+
+            // Act
+            var first = await client.GetAsync("https://localhost/resource");
+            var second = await client.GetAsync("https://localhost/resource");
+
+            // Assert
+            first.StatusCode.Should().Be(HttpStatusCode.OK);
+            second.StatusCode.Should().Be(HttpStatusCode.OK);
+        }
+
+        [Fact]
+        public async Task Sequenced_json_responses_produce_different_bodies()
+        {
+            // Arrange
+            var mock = new HttpMock();
+            mock.ForGet().WithPath("/resource")
+                .RespondsWithJsonContent(new { Page = 1 })
+                .ThenRespondsWithJsonContent(new { Page = 2 });
+
+            var client = mock.GetClient();
+
+            // Act
+            var firstBody = await (await client.GetAsync("https://localhost/resource")).Content.ReadAsStringAsync();
+            var secondBody = await (await client.GetAsync("https://localhost/resource")).Content.ReadAsStringAsync();
+
+            // Assert
+            firstBody.Should().Contain("\"Page\":1");
+            secondBody.Should().Contain("\"Page\":2");
+        }
+
+        [Fact]
+        public async Task A_sequence_can_be_combined_with_collecting_requests()
+        {
+            // Arrange
+            var mock = new HttpMock();
+            var requests = new RequestCollection();
+            mock.ForGet().WithPath("/resource")
+                .CollectingRequestsIn(requests)
+                .RespondsWithStatus(HttpStatusCode.ServiceUnavailable)
+                .ThenRespondsWithStatus(HttpStatusCode.OK);
+
+            var client = mock.GetClient();
+
+            // Act
+            var first = await client.GetAsync("https://localhost/resource");
+            var second = await client.GetAsync("https://localhost/resource");
+
+            // Assert
+            first.StatusCode.Should().Be(HttpStatusCode.ServiceUnavailable);
+            second.StatusCode.Should().Be(HttpStatusCode.OK);
+            requests.Should().HaveCount(2);
+            requests.ElementAt(0).Response.StatusCode.Should().Be(HttpStatusCode.ServiceUnavailable);
+            requests.ElementAt(1).Response.StatusCode.Should().Be(HttpStatusCode.OK);
+        }
+
+        [Fact]
+        public async Task A_sequence_combined_with_Times_stops_matching_after_the_limit()
+        {
+            // Arrange
+            var mock = new HttpMock();
+            mock.ForGet().WithPath("/resource")
+                .RespondsWithStatus(HttpStatusCode.ServiceUnavailable)
+                .ThenRespondsWithStatus(HttpStatusCode.OK)
+                .Times(2);
+
+            var client = mock.GetClient();
+
+            // Act
+            var first = await client.GetAsync("https://localhost/resource");
+            var second = await client.GetAsync("https://localhost/resource");
+            var third = await client.GetAsync("https://localhost/resource");
+            Func<Task> fourth = () => client.GetAsync("https://localhost/resource");
+
+            // Assert
+            // Times(2) applies to the last appended response (OK), so the sequence is:
+            // 1× ServiceUnavailable (promoted to count=1 when ThenXXX was called), then 2× OK, then exhausted.
+            first.StatusCode.Should().Be(HttpStatusCode.ServiceUnavailable);
+            second.StatusCode.Should().Be(HttpStatusCode.OK);
+            third.StatusCode.Should().Be(HttpStatusCode.OK);
+            await fourth.Should().ThrowAsync<UnexpectedRequestException>();
+        }
+
+        [Fact]
+        public async Task A_custom_responder_can_be_appended_to_the_sequence()
+        {
+            // Arrange
+            var mock = new HttpMock();
+            mock.ForGet().WithPath("/resource")
+                .RespondsWithStatus(HttpStatusCode.Accepted)
+                .ThenRespondsWith(_ => new HttpResponseMessage(HttpStatusCode.Created));
+
+            var client = mock.GetClient();
+
+            // Act
+            var first = await client.GetAsync("https://localhost/resource");
+            var second = await client.GetAsync("https://localhost/resource");
+
+            // Assert
+            first.StatusCode.Should().Be(HttpStatusCode.Accepted);
+            second.StatusCode.Should().Be(HttpStatusCode.Created);
+        }
+
+        [Fact]
+        public void The_Responder_property_still_exposes_the_first_response()
+        {
+            // Arrange
+            var mock = new HttpMock();
+            mock.ForGet().WithPath("/resource")
+                .RespondsWithStatus(HttpStatusCode.BadGateway)
+                .ThenRespondsWithStatus(HttpStatusCode.OK);
+
+            // Act
+            var uninvoked = mock.GetUninvokedMocks().First();
+            var request = new RequestInfo(new HttpRequestMessage(HttpMethod.Get, "https://localhost/resource"), body: null);
+            var firstResponse = uninvoked.Responder(request);
+
+            // Assert
+            firstResponse.StatusCode.Should().Be(HttpStatusCode.BadGateway);
+        }
+
+        [Fact]
+        public async Task Then_with_http_content_serves_that_content_as_the_next_response()
+        {
+            // Arrange
+            var mock = new HttpMock();
+            mock.ForGet().WithPath("/resource")
+                .RespondsWithStatus(HttpStatusCode.NotFound)
+                .ThenRespondsWith(new StringContent("hello"));
+
+            var client = mock.GetClient();
+
+            // Act
+            var first = await client.GetAsync("https://localhost/resource");
+            var second = await client.GetAsync("https://localhost/resource");
+
+            // Assert
+            first.StatusCode.Should().Be(HttpStatusCode.NotFound);
+            second.StatusCode.Should().Be(HttpStatusCode.OK);
+            (await second.Content.ReadAsStringAsync()).Should().Be("hello");
+        }
+
+        [Fact]
+        public async Task Then_with_status_and_http_content_serves_that_status_and_content()
+        {
+            // Arrange
+            var mock = new HttpMock();
+            mock.ForGet().WithPath("/resource")
+                .RespondsWithStatus(HttpStatusCode.NotFound)
+                .ThenRespondsWith(HttpStatusCode.Created, new StringContent("created"));
+
+            var client = mock.GetClient();
+
+            // Act
+            var first = await client.GetAsync("https://localhost/resource");
+            var second = await client.GetAsync("https://localhost/resource");
+
+            // Assert
+            first.StatusCode.Should().Be(HttpStatusCode.NotFound);
+            second.StatusCode.Should().Be(HttpStatusCode.Created);
+            (await second.Content.ReadAsStringAsync()).Should().Be("created");
+        }
+
+        [Fact]
+        public async Task An_appended_json_response_using_a_builder_produces_the_serialized_body()
+        {
+            // Arrange
+            var mock = new HttpMock();
+            mock.ForGet().WithPath("/resource")
+                .RespondsWithStatus(HttpStatusCode.NotFound)
+                .ThenRespondsWithJsonContent(new ItemBuilder().WithId(42));
+
+            var client = mock.GetClient();
+
+            // Act
+            var first = await client.GetAsync("https://localhost/resource");
+            var second = await client.GetAsync("https://localhost/resource");
+
+            // Assert
+            first.StatusCode.Should().Be(HttpStatusCode.NotFound);
+            second.StatusCode.Should().Be(HttpStatusCode.OK);
+            (await second.Content.ReadAsStringAsync()).Should().Contain("\"Id\":42");
+        }
+
+        [Fact]
+        public async Task An_appended_json_response_using_a_builder_can_use_a_custom_status_code()
+        {
+            // Arrange
+            var mock = new HttpMock();
+            mock.ForGet().WithPath("/resource")
+                .RespondsWithStatus(HttpStatusCode.NotFound)
+                .ThenRespondsWithJsonContent(HttpStatusCode.Accepted, new ItemBuilder().WithId(7));
+
+            var client = mock.GetClient();
+
+            // Act
+            var first = await client.GetAsync("https://localhost/resource");
+            var second = await client.GetAsync("https://localhost/resource");
+
+            // Assert
+            first.StatusCode.Should().Be(HttpStatusCode.NotFound);
+            second.StatusCode.Should().Be(HttpStatusCode.Accepted);
+            (await second.Content.ReadAsStringAsync()).Should().Contain("\"Id\":7");
+        }
+
+        [Fact]
+        public async Task An_appended_odata_response_with_a_single_object_wraps_it_in_an_envelope()
+        {
+            // Arrange
+            var mock = new HttpMock();
+            mock.ForGet().WithPath("/resource")
+                .RespondsWithStatus(HttpStatusCode.NotFound)
+                .ThenRespondsWithODataResult(new { Id = 1 });
+
+            var client = mock.GetClient();
+
+            // Act
+            var first = await client.GetAsync("https://localhost/resource");
+            var second = await client.GetAsync("https://localhost/resource");
+
+            // Assert
+            first.StatusCode.Should().Be(HttpStatusCode.NotFound);
+            second.StatusCode.Should().Be(HttpStatusCode.OK);
+            (await second.Content.ReadAsStringAsync()).Should().Contain("\"value\"");
+        }
+
+        [Fact]
+        public async Task An_appended_odata_response_with_a_collection_wraps_it_in_an_envelope()
+        {
+            // Arrange
+            var mock = new HttpMock();
+            mock.ForGet().WithPath("/resource")
+                .RespondsWithStatus(HttpStatusCode.NotFound)
+                .ThenRespondsWithODataResult([new { Id = 1 }, new { Id = 2 }]);
+
+            var client = mock.GetClient();
+
+            // Act
+            var first = await client.GetAsync("https://localhost/resource");
+            var second = await client.GetAsync("https://localhost/resource");
+
+            // Assert
+            first.StatusCode.Should().Be(HttpStatusCode.NotFound);
+            second.StatusCode.Should().Be(HttpStatusCode.OK);
+            (await second.Content.ReadAsStringAsync()).Should().Contain("\"value\"");
+        }
+
+        [Fact]
+        public async Task An_appended_odata_response_can_include_the_odata_context()
+        {
+            // Arrange
+            const string context = "https://localhost/$metadata#Items";
+            var mock = new HttpMock();
+            mock.ForGet().WithPath("/resource")
+                .RespondsWithStatus(HttpStatusCode.NotFound)
+                .ThenRespondsWithODataResult(HttpStatusCode.OK, [new { Id = 1 }], context);
+
+            var client = mock.GetClient();
+
+            // Act
+            var first = await client.GetAsync("https://localhost/resource");
+            var second = await client.GetAsync("https://localhost/resource");
+
+            // Assert
+            first.StatusCode.Should().Be(HttpStatusCode.NotFound);
+            (await second.Content.ReadAsStringAsync()).Should().Contain("@odata.context").And.Contain(context);
+        }
+
+        [Fact]
+        public async Task An_appended_odata_response_using_a_single_builder_wraps_it_in_an_envelope()
+        {
+            // Arrange
+            var mock = new HttpMock();
+            mock.ForGet().WithPath("/resource")
+                .RespondsWithStatus(HttpStatusCode.NotFound)
+                .ThenRespondsWithODataResult(new ItemBuilder().WithId(99));
+
+            var client = mock.GetClient();
+
+            // Act
+            var first = await client.GetAsync("https://localhost/resource");
+            var second = await client.GetAsync("https://localhost/resource");
+
+            // Assert
+            first.StatusCode.Should().Be(HttpStatusCode.NotFound);
+            second.StatusCode.Should().Be(HttpStatusCode.OK);
+            (await second.Content.ReadAsStringAsync()).Should().Contain("\"Id\":99");
+        }
+
+        [Fact]
+        public async Task An_appended_odata_response_using_a_builder_collection_wraps_them_in_an_envelope()
+        {
+            // Arrange
+            var builders = new[]
+            {
+                new ItemBuilder().WithId(10),
+                new ItemBuilder().WithId(20)
+            };
+            var mock = new HttpMock();
+            mock.ForGet().WithPath("/resource")
+                .RespondsWithStatus(HttpStatusCode.NotFound)
+                .ThenRespondsWithODataResult(HttpStatusCode.OK, builders);
+
+            var client = mock.GetClient();
+
+            // Act
+            var first = await client.GetAsync("https://localhost/resource");
+            var second = await client.GetAsync("https://localhost/resource");
+
+            // Assert
+            first.StatusCode.Should().Be(HttpStatusCode.NotFound);
+            second.StatusCode.Should().Be(HttpStatusCode.OK);
+            var body = await second.Content.ReadAsStringAsync();
+            body.Should().Contain("\"Id\":10").And.Contain("\"Id\":20");
+        }
+
+        [Fact]
+        public async Task An_appended_odata_response_using_a_builder_collection_can_include_the_odata_context()
+        {
+            // Arrange
+            const string context = "https://localhost/$metadata#Items";
+            var builders = new[] { new ItemBuilder().WithId(5) };
+            var mock = new HttpMock();
+            mock.ForGet().WithPath("/resource")
+                .RespondsWithStatus(HttpStatusCode.NotFound)
+                .ThenRespondsWithODataResult(HttpStatusCode.OK, builders, context);
+
+            var client = mock.GetClient();
+
+            // Act
+            var first = await client.GetAsync("https://localhost/resource");
+            var second = await client.GetAsync("https://localhost/resource");
+
+            // Assert
+            first.StatusCode.Should().Be(HttpStatusCode.NotFound);
+            (await second.Content.ReadAsStringAsync()).Should().Contain("@odata.context").And.Contain(context);
+        }
+
+        [Fact]
+        public async Task An_appended_odata_response_can_use_a_custom_status_code()
+        {
+            // Arrange
+            var mock = new HttpMock();
+            mock.ForGet().WithPath("/resource")
+                .RespondsWithStatus(HttpStatusCode.NotFound)
+                .ThenRespondsWithODataResult(HttpStatusCode.Accepted, new { Id = 3 });
+
+            var client = mock.GetClient();
+
+            // Act
+            var first = await client.GetAsync("https://localhost/resource");
+            var second = await client.GetAsync("https://localhost/resource");
+
+            // Assert
+            first.StatusCode.Should().Be(HttpStatusCode.NotFound);
+            second.StatusCode.Should().Be(HttpStatusCode.Accepted);
+        }
+
+        [Fact]
+        public async Task An_appended_odata_response_using_a_builder_can_use_a_custom_status_code()
+        {
+            // Arrange
+            var mock = new HttpMock();
+            mock.ForGet().WithPath("/resource")
+                .RespondsWithStatus(HttpStatusCode.NotFound)
+                .ThenRespondsWithODataResult(HttpStatusCode.Created, new ItemBuilder().WithId(11));
+
+            var client = mock.GetClient();
+
+            // Act
+            var first = await client.GetAsync("https://localhost/resource");
+            var second = await client.GetAsync("https://localhost/resource");
+
+            // Assert
+            first.StatusCode.Should().Be(HttpStatusCode.NotFound);
+            second.StatusCode.Should().Be(HttpStatusCode.Created);
+        }
+
+        [Fact]
+        public async Task An_appended_odata_response_using_enumerable_builders_wraps_them_in_an_envelope()
+        {
+            // Arrange
+            IEnumerable<ItemBuilder> builders = [new ItemBuilder().WithId(1), new ItemBuilder().WithId(2)];
+            var mock = new HttpMock();
+            mock.ForGet().WithPath("/resource")
+                .RespondsWithStatus(HttpStatusCode.NotFound)
+                .ThenRespondsWithODataResult(builders);
+
+            var client = mock.GetClient();
+
+            // Act
+            var first = await client.GetAsync("https://localhost/resource");
+            var second = await client.GetAsync("https://localhost/resource");
+
+            // Assert
+            first.StatusCode.Should().Be(HttpStatusCode.NotFound);
+            (await second.Content.ReadAsStringAsync()).Should().Contain("\"value\"");
+        }
+
+        [Fact]
+        public async Task An_appended_string_content_response_serves_that_body()
+        {
+            // Arrange
+            var mock = new HttpMock();
+            mock.ForGet().WithPath("/resource")
+                .RespondsWithStatus(HttpStatusCode.NotFound)
+                .ThenRespondsWithContent("{\"ok\":true}");
+
+            var client = mock.GetClient();
+
+            // Act
+            var first = await client.GetAsync("https://localhost/resource");
+            var second = await client.GetAsync("https://localhost/resource");
+
+            // Assert
+            first.StatusCode.Should().Be(HttpStatusCode.NotFound);
+            second.StatusCode.Should().Be(HttpStatusCode.OK);
+            (await second.Content.ReadAsStringAsync()).Should().Contain("\"ok\"");
+        }
+
+        [Fact]
+        public async Task An_appended_string_content_response_can_use_a_custom_status_and_content_type()
+        {
+            // Arrange
+            var mock = new HttpMock();
+            mock.ForGet().WithPath("/resource")
+                .RespondsWithStatus(HttpStatusCode.NotFound)
+                .ThenRespondsWithContent(HttpStatusCode.Accepted, "<root/>", "application/xml");
+
+            var client = mock.GetClient();
+
+            // Act
+            var first = await client.GetAsync("https://localhost/resource");
+            var second = await client.GetAsync("https://localhost/resource");
+
+            // Assert
+            first.StatusCode.Should().Be(HttpStatusCode.NotFound);
+            second.StatusCode.Should().Be(HttpStatusCode.Accepted);
+            second.Content.Headers.ContentType!.MediaType.Should().Be("application/xml");
+        }
+
+        [Fact]
+        public async Task An_appended_empty_content_response_uses_no_content_status_by_default()
+        {
+            // Arrange
+            var mock = new HttpMock();
+            mock.ForGet().WithPath("/resource")
+                .RespondsWithStatus(HttpStatusCode.OK)
+                .ThenRespondsWithEmptyContent();
+
+            var client = mock.GetClient();
+
+            // Act
+            var first = await client.GetAsync("https://localhost/resource");
+            var second = await client.GetAsync("https://localhost/resource");
+
+            // Assert
+            first.StatusCode.Should().Be(HttpStatusCode.OK);
+            second.StatusCode.Should().Be(HttpStatusCode.NoContent);
+        }
+
+        [Fact]
+        public async Task An_appended_empty_content_response_can_use_a_custom_status_code()
+        {
+            // Arrange
+            var mock = new HttpMock();
+            mock.ForGet().WithPath("/resource")
+                .RespondsWithStatus(HttpStatusCode.OK)
+                .ThenRespondsWithEmptyContent(HttpStatusCode.Accepted);
+
+            var client = mock.GetClient();
+
+            // Act
+            var first = await client.GetAsync("https://localhost/resource");
+            var second = await client.GetAsync("https://localhost/resource");
+
+            // Assert
+            first.StatusCode.Should().Be(HttpStatusCode.OK);
+            second.StatusCode.Should().Be(HttpStatusCode.Accepted);
+        }
+
+        private class ItemBuilder : IResponseBuilder<object>
+        {
+            private int id;
+
+            public ItemBuilder WithId(int value)
+            {
+                id = value;
+                return this;
+            }
+
+            public object Build() => new { Id = id };
         }
     }
 
@@ -3901,3 +4469,5 @@ public class HttpMockSpecs
         }
     }
 }
+
+

--- a/Mockly/HttpMock.cs
+++ b/Mockly/HttpMock.cs
@@ -178,6 +178,10 @@ public class HttpMock
         return For(HttpMethod.Options, urlPattern);
     }
 
+    /// <summary>
+    /// Creates a new <see cref="RequestMockBuilder"/> for the given <paramref name="method"/>,
+    /// inheriting settings from the previous builder when one exists.
+    /// </summary>
     private RequestMockBuilder Create(HttpMethod method)
     {
         RequestMockBuilder builder = previousBuilder != null
@@ -250,11 +254,21 @@ public class HttpMock
         return new MockHttpMessageHandler(this);
     }
 
+    /// <summary>
+    /// Registers a fully configured <see cref="RequestMock"/> with this instance so it is
+    /// evaluated during request matching.
+    /// </summary>
     internal void AddMock(RequestMock mock)
     {
         mocks.Add(mock);
     }
 
+    /// <summary>
+    /// Intercepts an outgoing HTTP request, finds the first non-exhausted matching mock,
+    /// and returns its configured response. Records the request in <see cref="Requests"/> and
+    /// throws <see cref="UnexpectedRequestException"/> when no mock matches and
+    /// <see cref="FailOnUnexpectedCalls"/> is <c>true</c>.
+    /// </summary>
     private async Task<HttpResponseMessage> HandleRequest(HttpRequestMessage httpRequest, CancellationToken cancellationToken)
     {
         RequestInfo request = await BuildRequestInfo(httpRequest);
@@ -288,6 +302,11 @@ public class HttpMock
         return capturedRequest.Response;
     }
 
+    /// <summary>
+    /// Builds a detailed diagnostic message that includes the unmatched request, the closest
+    /// matching mock (if any), and all registered mocks, then throws an
+    /// <see cref="UnexpectedRequestException"/>.
+    /// </summary>
     private async Task ThrowDetailedException(RequestInfo request)
     {
         // Determine the closest matching mock (if any) based on a similarity score.
@@ -369,6 +388,10 @@ public class HttpMock
         throw new UnexpectedRequestException(messageBuilder.ToString());
     }
 
+    /// <summary>
+    /// Converts an <see cref="HttpRequestMessage"/> into a <see cref="RequestInfo"/>,
+    /// optionally pre-reading the body when <see cref="PrefetchBody"/> is <c>true</c>.
+    /// </summary>
     private async Task<RequestInfo> BuildRequestInfo(HttpRequestMessage httpRequest)
     {
         string? body = null;
@@ -381,6 +404,10 @@ public class HttpMock
         return request;
     }
 
+    /// <summary>
+    /// Finds the first non-exhausted mock that matches <paramref name="request"/>, invokes it,
+    /// and returns the resulting <see cref="CapturedRequest"/>. Returns <c>null</c> when no mock matches.
+    /// </summary>
     private async Task<CapturedRequest?> TryFindMatchingMock(RequestInfo request, CancellationToken cancellationToken)
     {
         RequestMock? matchingMock = await mocks.FirstOrDefaultAsync(m =>
@@ -439,6 +466,11 @@ public class HttpMock
         }
     }
 
+    /// <summary>
+    /// Parses a full URL pattern (e.g. <c>"https://api.example.com/v1/users?active=*"</c>) and
+    /// applies the scheme, host, path, and query segments to <paramref name="builder"/>.
+    /// Wildcards (<c>*</c>) are supported in every segment.
+    /// </summary>
     private static RequestMockBuilder ApplyUrlPattern(RequestMockBuilder builder, string urlPattern)
     {
         if (string.IsNullOrWhiteSpace(urlPattern))

--- a/Mockly/RequestMock.cs
+++ b/Mockly/RequestMock.cs
@@ -82,7 +82,7 @@ public class RequestMock
         }
 
         // ReSharper disable once PropertyCanBeMadeInitOnly.Global
-        internal set
+        set
         {
             Func<RequestInfo, HttpResponseMessage> captured = value;
             lock (respondersLock)
@@ -436,6 +436,18 @@ public class RequestMock
         {
             responseMutators.Add(responseMutator);
         }
+    }
+
+    /// <summary>
+    /// Handles the request and returns a response using the configured responder sequence.
+    /// </summary>
+    /// <remarks>
+    /// This synchronous API is preserved for backward compatibility. Internally it delegates
+    /// to the asynchronous execution path without a cancellation token.
+    /// </remarks>
+    public CapturedRequest TrackRequest(RequestInfo request)
+    {
+        return TrackRequestAsync(request, CancellationToken.None).GetAwaiter().GetResult();
     }
 
     /// <summary>

--- a/Mockly/RequestMock.cs
+++ b/Mockly/RequestMock.cs
@@ -2,7 +2,7 @@ using System.Collections.Concurrent;
 using System.Net;
 using System.Text.RegularExpressions;
 using Mockly.Common;
-#if NET472
+#if NET472_OR_GREATER
 using System.Net.Http;
 #endif
 
@@ -15,32 +15,87 @@ public class RequestMock
 {
     private static readonly ConcurrentDictionary<string, Regex> RegexCache = new(StringComparer.OrdinalIgnoreCase);
     private readonly object hostNormalizationLock = new();
+    private readonly object respondersLock = new();
+
+    private readonly List<(Func<RequestInfo, CancellationToken, Task<HttpResponseMessage>> Responder, uint? Count)> responders
+        = [(static (_, _) => Task.FromResult(new HttpResponseMessage()), null)];
+
+    private readonly List<Action<HttpResponseMessage>> responseMutators = [];
     private int invocationCount;
 
     private bool hostPatternNormalized;
 
+    /// <summary>
+    /// Gets the HTTP method this mock matches against.
+    /// </summary>
     public HttpMethod Method { get; init; } = HttpMethod.Get;
 
+    /// <summary>
+    /// Gets the path pattern this mock matches against, supporting wildcards (<c>*</c>).
+    /// When <c>null</c>, any path is accepted.
+    /// </summary>
     public string? PathPattern { get; init; }
 
+    /// <summary>
+    /// Gets the query string pattern this mock matches against, supporting wildcards (<c>*</c>).
+    /// When <c>null</c>, requests without a query string are accepted (unless custom matchers are configured).
+    /// </summary>
     public string? QueryPattern { get; init; }
 
     // REFACTOR: Should not be nullable in the future and replaced with an enum
-    public string? Scheme { get; init; }
-
-    public string? HostPattern { get; set; }
-
-    public IEnumerable<Matcher> CustomMatchers { get; internal init; } = [];
-
-    public Func<RequestInfo, HttpResponseMessage> Responder { get; set; } = _ => new HttpResponseMessage();
 
     /// <summary>
-    /// Gets the asynchronous responder used to produce a response for a matching request.
-    /// When set, this takes precedence over <see cref="Responder"/> and receives the
-    /// <see cref="CancellationToken"/> flowing from the HTTP pipeline.
+    /// Gets the URI scheme this mock matches against (e.g. <c>"http"</c> or <c>"https"</c>).
+    /// When <c>null</c>, both schemes are accepted.
     /// </summary>
-    internal Func<RequestInfo, CancellationToken, Task<HttpResponseMessage>>? AsyncResponder { get; init; }
+    public string? Scheme { get; init; }
 
+    /// <summary>
+    /// Gets or sets the host pattern this mock matches against, supporting wildcards (<c>*</c>).
+    /// When <c>null</c>, any host is accepted.
+    /// </summary>
+    public string? HostPattern { get; set; }
+
+    /// <summary>
+    /// Gets the custom matchers that are evaluated in addition to the standard route criteria.
+    /// All matchers must return <c>true</c> for the mock to match a request.
+    /// </summary>
+    public IEnumerable<Matcher> CustomMatchers { get; internal init; } = [];
+
+    /// <summary>
+    /// Gets or sets the responder used to produce a response for a matched request.
+    /// </summary>
+    /// <remarks>
+    /// This is the first (or only) responder in the configured sequence. Additional responders can be appended
+    /// through the fluent <c>Then*</c> methods on <see cref="SequencedResponseBuilder"/>, in which case this
+    /// property continues to represent the response returned for the first invocation.
+    /// </remarks>
+    public Func<RequestInfo, HttpResponseMessage> Responder
+    {
+        get
+        {
+            lock (respondersLock)
+            {
+                Func<RequestInfo, CancellationToken, Task<HttpResponseMessage>> asyncFn = responders[0].Responder;
+                return request => asyncFn(request, CancellationToken.None).GetAwaiter().GetResult();
+            }
+        }
+
+        // ReSharper disable once PropertyCanBeMadeInitOnly.Global
+        internal set
+        {
+            Func<RequestInfo, HttpResponseMessage> captured = value;
+            lock (respondersLock)
+            {
+                responders[0] = ((req, _) => Task.FromResult(captured(req)), responders[0].Count);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Gets the collection that receives every <see cref="CapturedRequest"/> handled by this mock.
+    /// When <c>null</c>, captured requests are not stored.
+    /// </summary>
     public RequestCollection? RequestCollection { get; init; } = [];
 
     /// <summary>
@@ -52,7 +107,28 @@ public class RequestMock
     /// Gets the maximum number of times this mock can be invoked.
     /// If <c>null</c>, the mock can be invoked unlimited times.
     /// </summary>
-    public uint? MaxInvocations { get; internal set; }
+    public uint? MaxInvocations
+    {
+        get
+        {
+            lock (respondersLock)
+            {
+                if (responders[^1].Count is null)
+                {
+                    return null;
+                }
+
+                uint total = 0;
+
+                foreach ((_, uint? count) in responders)
+                {
+                    total += count!.Value;
+                }
+
+                return total;
+            }
+        }
+    }
 
     /// <summary>
     /// Gets a value indicating whether this mock has been exhausted, i.e.
@@ -246,6 +322,11 @@ public class RequestMock
         return score;
     }
 
+    /// <summary>
+    /// Returns <c>true</c> when <paramref name="value"/> matches <paramref name="pattern"/>,
+    /// where <c>*</c> in the pattern acts as a wildcard. Matching is case-insensitive.
+    /// Compiled regexes are cached to avoid repeated compilation.
+    /// </summary>
     private static bool MatchesPattern(string value, string pattern)
     {
         // Convert wildcard pattern to regex and cache it
@@ -259,41 +340,102 @@ public class RequestMock
     }
 
     /// <summary>
-    /// Handles the request and returns a response.
+    /// Appends a responder to the configured sequence of responses.
     /// </summary>
     /// <remarks>
-    /// This synchronous overload only invokes the synchronous <see cref="Responder"/> and is preserved for
-    /// backwards compatibility. The HTTP pipeline uses <see cref="TrackRequestAsync"/> so that asynchronous
-    /// responders and cancellation are honored.
+    /// Consecutive matching requests are served by consecutive responders. Once the sequence is exhausted,
+    /// the last responder is repeated for every subsequent request.
+    /// When a new responder is appended, the previously-last entry's unlimited slot is promoted to a
+    /// single-use count so the sequence advances after one invocation by default.
     /// </remarks>
-    public CapturedRequest TrackRequest(RequestInfo request)
+    internal void AppendResponder(Func<RequestInfo, HttpResponseMessage> responder)
     {
-        Interlocked.Increment(ref invocationCount);
+        Func<RequestInfo, HttpResponseMessage> captured = responder;
 
-        CapturedRequest capturedRequest = new(request)
+        lock (respondersLock)
         {
-            Mock = this,
-            WasExpected = true,
-            Timestamp = DateTime.UtcNow
-        };
-
-        try
-        {
-            capturedRequest.Response = Responder(request);
+            ConvertLastResponderToSingleUse();
+            responders.Add(((req, _) => Task.FromResult(captured(req)), null));
         }
-#pragma warning disable CA1031
-        catch (Exception e)
-#pragma warning restore CA1031
+    }
+
+    /// <summary>
+    /// Appends an asynchronous responder to the configured sequence of responses.
+    /// </summary>
+    internal void AppendAsyncResponder(Func<RequestInfo, CancellationToken, Task<HttpResponseMessage>> responder)
+    {
+        lock (respondersLock)
         {
-            capturedRequest.Response = new HttpResponseMessage(HttpStatusCode.InternalServerError)
-            {
-                ReasonPhrase = $"{e.GetType().Name}:{e.Message}"
-            };
+            ConvertLastResponderToSingleUse();
+            responders.Add((responder, null));
         }
+    }
 
-        RequestCollection?.Add(capturedRequest);
+    /// <summary>
+    /// Sets the count for the most recently configured response in the sequence.
+    /// </summary>
+    /// <remarks>
+    /// When this response's count is exhausted the sequence advances to the next entry. If this is the last
+    /// entry in the sequence the mock becomes exhausted and stops matching further requests.
+    /// </remarks>
+    internal void SetCurrentResponseCount(uint count)
+    {
+        lock (respondersLock)
+        {
+            (Func<RequestInfo, CancellationToken, Task<HttpResponseMessage>> responder, _) = responders[^1];
+            responders[^1] = (responder, count);
+        }
+    }
 
-        return capturedRequest;
+    /// <summary>
+    /// Replaces the first (initial) responder with an asynchronous function.
+    /// Used by the async <c>RespondsWith</c> overloads to set the primary async responder.
+    /// </summary>
+    internal void SetFirstAsyncResponder(Func<RequestInfo, CancellationToken, Task<HttpResponseMessage>> responder)
+    {
+        lock (respondersLock)
+        {
+            responders[0] = (responder, responders[0].Count);
+        }
+    }
+
+    /// <summary>
+    /// Converts the current last responder from an unlimited response to a single-use response.
+    /// </summary>
+    /// <remarks>
+    /// Appended responders are unlimited by default. When a new responder is appended, the previously last
+    /// responder must become single-use so the sequence can advance to the new responder after one invocation.
+    /// </remarks>
+    private void ConvertLastResponderToSingleUse()
+    {
+        (Func<RequestInfo, CancellationToken, Task<HttpResponseMessage>> lastResponder, uint? lastCount) = responders[^1];
+
+        if (lastCount is null)
+        {
+            responders[^1] = (lastResponder, Count: 1);
+        }
+    }
+
+    /// <summary>
+    /// Registers a post-processing callback that is applied to every <see cref="HttpResponseMessage"/>
+    /// produced by this mock, after the responder generates it.
+    /// </summary>
+    /// <remarks>
+    /// Multiple mutators can be registered; they are applied in registration order.
+    /// Mutators are called by builder classes (e.g. <c>RequestMockResponseBuilder</c>) when the user
+    /// chains response-modification methods such as <c>WithHeader</c>, keeping post-processing concerns
+    /// separate from the responder sequence.
+    /// </remarks>
+    /// <param name="responseMutator">
+    /// A delegate that receives the response and can modify it in-place, for example by adding headers
+    /// or changing the status code.
+    /// </param>
+    internal void AppendResponseMutator(Action<HttpResponseMessage> responseMutator)
+    {
+        lock (respondersLock)
+        {
+            responseMutators.Add(responseMutator);
+        }
     }
 
     /// <summary>
@@ -305,7 +447,7 @@ public class RequestMock
     /// </remarks>
     internal async Task<CapturedRequest> TrackRequestAsync(RequestInfo request, CancellationToken cancellationToken)
     {
-        Interlocked.Increment(ref invocationCount);
+        int invocationIndex = Interlocked.Increment(ref invocationCount) - 1;
 
         CapturedRequest capturedRequest = new(request)
         {
@@ -316,7 +458,7 @@ public class RequestMock
 
         try
         {
-            capturedRequest.Response = await InvokeResponderAsync(request, cancellationToken);
+            capturedRequest.Response = ApplyResponseMutators(await InvokeResponderAsync(request, invocationIndex, cancellationToken));
         }
         catch (OperationCanceledException)
         {
@@ -338,14 +480,62 @@ public class RequestMock
     }
 
     /// <summary>
-    /// Invokes the asynchronous responder when configured; otherwise adapts the synchronous
-    /// <see cref="Responder"/> onto the asynchronous path.
+    /// Invokes the responder for the given invocation index, awaiting asynchronous responders and
+    /// flowing the supplied <paramref name="cancellationToken"/> into them.
     /// </summary>
-    private Task<HttpResponseMessage> InvokeResponderAsync(RequestInfo request, CancellationToken cancellationToken)
+    private Task<HttpResponseMessage> InvokeResponderAsync(RequestInfo request, int invocationIndex, CancellationToken cancellationToken)
     {
-        return AsyncResponder is not null
-            ? AsyncResponder(request, cancellationToken)
-            : Task.FromResult(Responder(request));
+        return GetResponderForInvocation(invocationIndex)(request, cancellationToken);
+    }
+
+    /// <summary>
+    /// Returns the responder that should handle the given zero-based <paramref name="invocationIndex"/>
+    /// by walking the sequence and subtracting each entry's count until the correct slot is found.
+    /// Falls back to the last responder once the sequence is exhausted.
+    /// </summary>
+    private Func<RequestInfo, CancellationToken, Task<HttpResponseMessage>> GetResponderForInvocation(int invocationIndex)
+    {
+        lock (respondersLock)
+        {
+            long remaining = invocationIndex;
+
+            foreach ((Func<RequestInfo, CancellationToken, Task<HttpResponseMessage>> responder, uint? count) in responders)
+            {
+                if (count is null)
+                {
+                    return responder;
+                }
+
+                if (remaining < count.Value)
+                {
+                    return responder;
+                }
+
+                remaining -= count.Value;
+            }
+
+            return responders[^1].Responder;
+        }
+    }
+
+    /// <summary>
+    /// Applies all registered response mutators to <paramref name="response"/> in registration order
+    /// and returns the (modified) response.
+    /// </summary>
+    private HttpResponseMessage ApplyResponseMutators(HttpResponseMessage response)
+    {
+        Action<HttpResponseMessage>[] mutators;
+        lock (respondersLock)
+        {
+            mutators = [.. responseMutators];
+        }
+
+        foreach (Action<HttpResponseMessage> mutator in mutators)
+        {
+            mutator(response);
+        }
+
+        return response;
     }
 
     /// <summary>

--- a/Mockly/RequestMockBuilder.cs
+++ b/Mockly/RequestMockBuilder.cs
@@ -6,12 +6,12 @@ using System.Runtime.CompilerServices;
 using System.Text;
 using System.Text.Json;
 using System.Text.RegularExpressions;
-using System.Threading;
-using System.Threading.Tasks;
 using Mockly.Common;
 
 #if NET472_OR_GREATER
 using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
 #endif
 
 namespace Mockly;
@@ -460,9 +460,9 @@ public class RequestMockBuilder
     }
 
     /// <summary>
-    /// Responds with the specified HTTP status code.
+    /// Creates a mock with the specified responder, registers it, and returns a builder for further configuration.
     /// </summary>
-    public RequestMockResponseBuilder RespondsWithStatus(HttpStatusCode statusCode)
+    private SequencedResponseBuilder CreateResponse(Func<RequestInfo, HttpResponseMessage> responder)
     {
         var mock = new RequestMock
         {
@@ -473,17 +473,25 @@ public class RequestMockBuilder
             HostPattern = hostPattern,
             CustomMatchers = customMatchers,
             RequestCollection = requestCollection,
-            Responder = _ => new HttpResponseMessage(statusCode)
+            Responder = responder
         };
 
         mockBuilder.AddMock(mock);
-        return new RequestMockResponseBuilder(mock);
+        return new SequencedResponseBuilder(mock, jsonSerializerOptions);
+    }
+
+    /// <summary>
+    /// Responds with the specified HTTP status code.
+    /// </summary>
+    public SequencedResponseBuilder RespondsWithStatus(HttpStatusCode statusCode)
+    {
+        return CreateResponse(ResponderFactory.Status(statusCode));
     }
 
     /// <summary>
     /// Responds with JSON content serialized from the specified object and status code 200 (OK).
     /// </summary>
-    public RequestMockResponseBuilder RespondsWithJsonContent(object content)
+    public SequencedResponseBuilder RespondsWithJsonContent(object content)
     {
         return RespondsWithJsonContent(HttpStatusCode.OK, content);
     }
@@ -493,7 +501,7 @@ public class RequestMockBuilder
     /// </summary>
     /// <typeparam name="T">The type of object to build and serialize.</typeparam>
     /// <param name="builder">The builder that will construct the object to serialize.</param>
-    public RequestMockResponseBuilder RespondsWithJsonContent<T>(IResponseBuilder<T> builder)
+    public SequencedResponseBuilder RespondsWithJsonContent<T>(IResponseBuilder<T> builder)
     {
         return RespondsWithJsonContent(HttpStatusCode.OK, builder);
     }
@@ -501,31 +509,9 @@ public class RequestMockBuilder
     /// <summary>
     /// Responds with JSON content serialized from the specified object and a specific status code.
     /// </summary>
-    public RequestMockResponseBuilder RespondsWithJsonContent(HttpStatusCode statusCode, object content)
+    public SequencedResponseBuilder RespondsWithJsonContent(HttpStatusCode statusCode, object content)
     {
-        var options = jsonSerializerOptions;
-
-        var mock = new RequestMock
-        {
-            Method = Method,
-            PathPattern = pathPattern,
-            QueryPattern = queryPattern,
-            Scheme = scheme,
-            HostPattern = hostPattern,
-            CustomMatchers = customMatchers,
-            RequestCollection = requestCollection,
-            Responder = _ =>
-            {
-                var json = JsonSerializer.Serialize(content, options);
-                return new HttpResponseMessage(statusCode)
-                {
-                    Content = new StringContent(json, Encoding.UTF8, "application/json")
-                };
-            }
-        };
-
-        mockBuilder.AddMock(mock);
-        return new RequestMockResponseBuilder(mock);
+        return CreateResponse(ResponderFactory.JsonContent(statusCode, content, jsonSerializerOptions));
     }
 
     /// <summary>
@@ -534,7 +520,7 @@ public class RequestMockBuilder
     /// <typeparam name="T">The type of object to build and serialize.</typeparam>
     /// <param name="statusCode">The HTTP status code to respond with.</param>
     /// <param name="builder">The builder that will construct the object to serialize.</param>
-    public RequestMockResponseBuilder RespondsWithJsonContent<T>(HttpStatusCode statusCode, IResponseBuilder<T> builder)
+    public SequencedResponseBuilder RespondsWithJsonContent<T>(HttpStatusCode statusCode, IResponseBuilder<T> builder)
     {
         object content = builder.Build()!;
         return RespondsWithJsonContent(statusCode, content);
@@ -561,7 +547,7 @@ public class RequestMockBuilder
         Justification = "The parameters mirror the RFC 7807 problem details members for an ergonomic single-call API.")]
     [SuppressMessage("Member Design", "AV1553:Do not use optional parameters with default value null",
         Justification = "The RFC 7807 members are all optional, so null is the natural way to omit them.")]
-    public RequestMockResponseBuilder RespondsWithProblemDetails(
+    public SequencedResponseBuilder RespondsWithProblemDetails(
         HttpStatusCode statusCode,
         string? title = null,
         string? detail = null,
@@ -619,7 +605,7 @@ public class RequestMockBuilder
         };
 
         mockBuilder.AddMock(mock);
-        return new RequestMockResponseBuilder(mock);
+        return new SequencedResponseBuilder(mock);
     }
 
     private static string? GetReasonPhrase(HttpStatusCode statusCode)
@@ -633,7 +619,7 @@ public class RequestMockBuilder
     /// and status code 200 (OK).
     /// </summary>
     /// <param name="value">The entity to include in the OData result.</param>
-    public RequestMockResponseBuilder RespondsWithODataResult(object value)
+    public SequencedResponseBuilder RespondsWithODataResult(object value)
     {
         return RespondsWithODataResult(HttpStatusCode.OK, [value]);
     }
@@ -644,7 +630,7 @@ public class RequestMockBuilder
     /// </summary>
     /// <typeparam name="T">The type of entity to build.</typeparam>
     /// <param name="builder">The builder that will construct the entity to include in the OData result.</param>
-    public RequestMockResponseBuilder RespondsWithODataResult<T>(IResponseBuilder<T> builder)
+    public SequencedResponseBuilder RespondsWithODataResult<T>(IResponseBuilder<T> builder)
     {
         return RespondsWithODataResult(HttpStatusCode.OK, builder);
     }
@@ -654,7 +640,7 @@ public class RequestMockBuilder
     /// </summary>
     /// <param name="statusCode">The HTTP status code for the response.</param>
     /// <param name="value">The entity to include in the OData result.</param>
-    public RequestMockResponseBuilder RespondsWithODataResult(HttpStatusCode statusCode,
+    public SequencedResponseBuilder RespondsWithODataResult(HttpStatusCode statusCode,
         object value)
     {
         return RespondsWithODataResult(statusCode, [value]);
@@ -666,7 +652,7 @@ public class RequestMockBuilder
     /// <typeparam name="T">The type of entity to build.</typeparam>
     /// <param name="statusCode">The HTTP status code for the response.</param>
     /// <param name="builder">The builder that will construct the entity to include in the OData result.</param>
-    public RequestMockResponseBuilder RespondsWithODataResult<T>(HttpStatusCode statusCode,
+    public SequencedResponseBuilder RespondsWithODataResult<T>(HttpStatusCode statusCode,
         IResponseBuilder<T> builder)
     {
         object value = builder.Build()!;
@@ -676,7 +662,7 @@ public class RequestMockBuilder
     /// <summary>
     /// Responds with an OData v4 result envelope: { "value": [...] } and status code 200 (OK).
     /// </summary>
-    public RequestMockResponseBuilder RespondsWithODataResult(IEnumerable<object> value)
+    public SequencedResponseBuilder RespondsWithODataResult(IEnumerable<object> value)
     {
         return RespondsWithODataResult(HttpStatusCode.OK, value);
     }
@@ -686,7 +672,7 @@ public class RequestMockBuilder
     /// </summary>
     /// <typeparam name="T">The type of entities to build.</typeparam>
     /// <param name="builders">The builders that will construct the entities to include in the OData result.</param>
-    public RequestMockResponseBuilder RespondsWithODataResult<T>(IEnumerable<IResponseBuilder<T>> builders)
+    public SequencedResponseBuilder RespondsWithODataResult<T>(IEnumerable<IResponseBuilder<T>> builders)
     {
         return RespondsWithODataResult(HttpStatusCode.OK, builders);
     }
@@ -694,37 +680,10 @@ public class RequestMockBuilder
     /// <summary>
     /// Responds with an OData v4 result envelope: { "value": [...] } and a specific status code.
     /// </summary>
-    public RequestMockResponseBuilder RespondsWithODataResult(HttpStatusCode statusCode,
+    public SequencedResponseBuilder RespondsWithODataResult(HttpStatusCode statusCode,
         IEnumerable<object> value)
     {
-        var options = jsonSerializerOptions;
-
-        var mock = new RequestMock
-        {
-            Method = Method,
-            PathPattern = pathPattern,
-            QueryPattern = queryPattern,
-            Scheme = scheme,
-            HostPattern = hostPattern,
-            CustomMatchers = customMatchers,
-            RequestCollection = requestCollection,
-            Responder = _ =>
-            {
-                var payload = new Dictionary<string, object?>(StringComparer.Ordinal)
-                {
-                    ["value"] = value.ToArray()
-                };
-
-                string json = JsonSerializer.Serialize(payload, options);
-                return new HttpResponseMessage(statusCode)
-                {
-                    Content = new StringContent(json, Encoding.UTF8, "application/json")
-                };
-            }
-        };
-
-        mockBuilder.AddMock(mock);
-        return new RequestMockResponseBuilder(mock);
+        return CreateResponse(ResponderFactory.ODataResult(statusCode, value, odataContext: null, jsonSerializerOptions));
     }
 
     /// <summary>
@@ -733,7 +692,7 @@ public class RequestMockBuilder
     /// <typeparam name="T">The type of entities to build.</typeparam>
     /// <param name="statusCode">The HTTP status code for the response.</param>
     /// <param name="builders">The builders that will construct the entities to include in the OData result.</param>
-    public RequestMockResponseBuilder RespondsWithODataResult<T>(HttpStatusCode statusCode,
+    public SequencedResponseBuilder RespondsWithODataResult<T>(HttpStatusCode statusCode,
         IEnumerable<IResponseBuilder<T>> builders)
     {
         var builtValues = builders.Select(b => b.Build()).Cast<object>();
@@ -743,42 +702,10 @@ public class RequestMockBuilder
     /// <summary>
     /// Responds with an OData v4 result envelope including the optional "@odata.context" value.
     /// </summary>
-    public RequestMockResponseBuilder RespondsWithODataResult(HttpStatusCode statusCode, IEnumerable<object> value,
+    public SequencedResponseBuilder RespondsWithODataResult(HttpStatusCode statusCode, IEnumerable<object> value,
         string odataContext)
     {
-        var options = jsonSerializerOptions;
-
-        var mock = new RequestMock
-        {
-            Method = Method,
-            PathPattern = pathPattern,
-            QueryPattern = queryPattern,
-            Scheme = scheme,
-            HostPattern = hostPattern,
-            CustomMatchers = customMatchers,
-            RequestCollection = requestCollection,
-            Responder = _ =>
-            {
-                var payload = new Dictionary<string, object?>(StringComparer.Ordinal)
-                {
-                    ["value"] = value.ToArray()
-                };
-
-                if (!string.IsNullOrWhiteSpace(odataContext))
-                {
-                    payload["@odata.context"] = odataContext;
-                }
-
-                string json = JsonSerializer.Serialize(payload, options);
-                return new HttpResponseMessage(statusCode)
-                {
-                    Content = new StringContent(json, Encoding.UTF8, "application/json")
-                };
-            }
-        };
-
-        mockBuilder.AddMock(mock);
-        return new RequestMockResponseBuilder(mock);
+        return CreateResponse(ResponderFactory.ODataResult(statusCode, value, odataContext, jsonSerializerOptions));
     }
 
     /// <summary>
@@ -788,7 +715,7 @@ public class RequestMockBuilder
     /// <param name="statusCode">The HTTP status code for the response.</param>
     /// <param name="builders">The builders that will construct the entities to include in the OData result.</param>
     /// <param name="odataContext">The OData context URL to include in the response.</param>
-    public RequestMockResponseBuilder RespondsWithODataResult<T>(HttpStatusCode statusCode, IEnumerable<IResponseBuilder<T>> builders,
+    public SequencedResponseBuilder RespondsWithODataResult<T>(HttpStatusCode statusCode, IEnumerable<IResponseBuilder<T>> builders,
         string odataContext)
     {
         var builtValues = builders.Select(b => b.Build()).Cast<object>();
@@ -800,7 +727,7 @@ public class RequestMockBuilder
     /// and a default content type of "application/json".
     /// </summary>
     /// <param name="content">The body content to return in the HTTP response.</param>
-    public RequestMockResponseBuilder RespondsWithContent(string content)
+    public SequencedResponseBuilder RespondsWithContent(string content)
     {
         return RespondsWithContent(HttpStatusCode.OK, content, "application/json");
     }
@@ -811,47 +738,18 @@ public class RequestMockBuilder
     /// <param name="statusCode">The HTTP status code to respond with.</param>
     /// <param name="content">The response content as a string.</param>
     /// <param name="contentType">The MIME type of the response content.</param>
-    public RequestMockResponseBuilder RespondsWithContent(HttpStatusCode statusCode, string content,
+    public SequencedResponseBuilder RespondsWithContent(HttpStatusCode statusCode, string content,
         string contentType = "application/json")
     {
-        var mock = new RequestMock
-        {
-            Method = Method,
-            PathPattern = pathPattern,
-            QueryPattern = queryPattern,
-            Scheme = scheme,
-            HostPattern = hostPattern,
-            CustomMatchers = customMatchers,
-            RequestCollection = requestCollection,
-            Responder = _ => new HttpResponseMessage(statusCode)
-            {
-                Content = new StringContent(content, Encoding.UTF8, contentType)
-            }
-        };
-
-        mockBuilder.AddMock(mock);
-        return new RequestMockResponseBuilder(mock);
+        return CreateResponse(ResponderFactory.Content(statusCode, content, contentType));
     }
 
     /// <summary>
     /// Responds with empty content.
     /// </summary>
-    public RequestMockResponseBuilder RespondsWithEmptyContent(HttpStatusCode statusCode = HttpStatusCode.NoContent)
+    public SequencedResponseBuilder RespondsWithEmptyContent(HttpStatusCode statusCode = HttpStatusCode.NoContent)
     {
-        var mock = new RequestMock
-        {
-            Method = Method,
-            PathPattern = pathPattern,
-            QueryPattern = queryPattern,
-            Scheme = scheme,
-            HostPattern = hostPattern,
-            CustomMatchers = customMatchers,
-            RequestCollection = requestCollection,
-            Responder = _ => new HttpResponseMessage(statusCode)
-        };
-
-        mockBuilder.AddMock(mock);
-        return new RequestMockResponseBuilder(mock);
+        return CreateResponse(ResponderFactory.Status(statusCode));
     }
 
     /// <summary>
@@ -867,7 +765,7 @@ public class RequestMockBuilder
     /// The MIME type of the response content. When <see langword="null"/>, the content type is inferred from the file extension.
     /// </param>
 #pragma warning disable AV1553 // Optional parameter defaults to null to mirror the documented public API contract.
-    public RequestMockResponseBuilder RespondsWithFile(string path, string? contentType = null)
+    public SequencedResponseBuilder RespondsWithFile(string path, string? contentType = null)
 #pragma warning restore AV1553
     {
         if (path is null)
@@ -906,7 +804,7 @@ public class RequestMockBuilder
         };
 
         mockBuilder.AddMock(mock);
-        return new RequestMockResponseBuilder(mock);
+        return new SequencedResponseBuilder(mock);
     }
 
     /// <summary>
@@ -915,7 +813,7 @@ public class RequestMockBuilder
     /// </summary>
     /// <param name="content">The bytes to return as the response body.</param>
     /// <param name="contentType">The MIME type of the response content.</param>
-    public RequestMockResponseBuilder RespondsWithBytes(byte[] content, string contentType)
+    public SequencedResponseBuilder RespondsWithBytes(byte[] content, string contentType)
     {
         if (content is null)
         {
@@ -954,7 +852,7 @@ public class RequestMockBuilder
         };
 
         mockBuilder.AddMock(mock);
-        return new RequestMockResponseBuilder(mock);
+        return new SequencedResponseBuilder(mock);
     }
 
     /// <summary>
@@ -967,7 +865,7 @@ public class RequestMockBuilder
     /// </remarks>
     /// <param name="stream">The stream whose contents are returned as the response body.</param>
     /// <param name="contentType">The MIME type of the response content.</param>
-    public RequestMockResponseBuilder RespondsWithStream(Stream stream, string contentType)
+    public SequencedResponseBuilder RespondsWithStream(Stream stream, string contentType)
     {
         if (stream is null)
         {
@@ -1005,7 +903,7 @@ public class RequestMockBuilder
         };
 
         mockBuilder.AddMock(mock);
-        return new RequestMockResponseBuilder(mock);
+        return new SequencedResponseBuilder(mock);
     }
 
     /// <summary>
@@ -1017,7 +915,7 @@ public class RequestMockBuilder
     /// If the mock will be called multiple times, consider using the <see cref="RespondsWith(Func{RequestInfo, HttpResponseMessage})"/>
     /// overload to create a new content instance for each request.
     /// </remarks>
-    public RequestMockResponseBuilder RespondsWith(HttpContent content)
+    public SequencedResponseBuilder RespondsWith(HttpContent content)
     {
         return RespondsWith(HttpStatusCode.OK, content);
     }
@@ -1032,53 +930,24 @@ public class RequestMockBuilder
     /// If the mock will be called multiple times, consider using the <see cref="RespondsWith(Func{RequestInfo, HttpResponseMessage})"/>
     /// overload to create a new content instance for each request.
     /// </remarks>
-    public RequestMockResponseBuilder RespondsWith(HttpStatusCode statusCode, HttpContent content)
+    public SequencedResponseBuilder RespondsWith(HttpStatusCode statusCode, HttpContent content)
     {
-        var mock = new RequestMock
-        {
-            Method = Method,
-            PathPattern = pathPattern,
-            QueryPattern = queryPattern,
-            Scheme = scheme,
-            HostPattern = hostPattern,
-            CustomMatchers = customMatchers,
-            RequestCollection = requestCollection,
-            Responder = _ => new HttpResponseMessage(statusCode)
-            {
-                Content = content
-            }
-        };
-
-        mockBuilder.AddMock(mock);
-        return new RequestMockResponseBuilder(mock);
+        return CreateResponse(ResponderFactory.HttpContent(statusCode, content));
     }
 
     /// <summary>
     /// Responds using a custom responder function.
     /// </summary>
-    public RequestMockResponseBuilder RespondsWith(Func<RequestInfo, HttpResponseMessage> responder)
+    public SequencedResponseBuilder RespondsWith(Func<RequestInfo, HttpResponseMessage> responder)
     {
-        var mock = new RequestMock
-        {
-            Method = Method,
-            PathPattern = pathPattern,
-            QueryPattern = queryPattern,
-            Scheme = scheme,
-            HostPattern = hostPattern,
-            CustomMatchers = customMatchers,
-            RequestCollection = requestCollection,
-            Responder = responder
-        };
-
-        mockBuilder.AddMock(mock);
-        return new RequestMockResponseBuilder(mock);
+        return CreateResponse(responder);
     }
 
     /// <summary>
     /// Responds using a custom asynchronous responder function that is awaited when producing the response.
     /// </summary>
     /// <param name="responder">An asynchronous function that produces the response for a matching request.</param>
-    public RequestMockResponseBuilder RespondsWith(Func<RequestInfo, Task<HttpResponseMessage>> responder)
+    public SequencedResponseBuilder RespondsWith(Func<RequestInfo, Task<HttpResponseMessage>> responder)
     {
         if (responder is null)
         {
@@ -1096,7 +965,7 @@ public class RequestMockBuilder
     /// An asynchronous function that produces the response for a matching request, observing the supplied
     /// <see cref="CancellationToken"/>.
     /// </param>
-    public RequestMockResponseBuilder RespondsWith(Func<RequestInfo, CancellationToken, Task<HttpResponseMessage>> responder)
+    public SequencedResponseBuilder RespondsWith(Func<RequestInfo, CancellationToken, Task<HttpResponseMessage>> responder)
     {
         if (responder is null)
         {
@@ -1112,11 +981,11 @@ public class RequestMockBuilder
             HostPattern = hostPattern,
             CustomMatchers = customMatchers,
             RequestCollection = requestCollection,
-            AsyncResponder = responder
         };
 
+        mock.SetFirstAsyncResponder(responder);
         mockBuilder.AddMock(mock);
-        return new RequestMockResponseBuilder(mock);
+        return new SequencedResponseBuilder(mock);
     }
 
     private static string InferContentTypeFromExtension(string path)
@@ -1140,3 +1009,4 @@ public class RequestMockBuilder
         };
     }
 }
+

--- a/Mockly/RequestMockResponseBuilder.cs
+++ b/Mockly/RequestMockResponseBuilder.cs
@@ -9,7 +9,7 @@ namespace Mockly;
 /// </summary>
 public class RequestMockResponseBuilder
 {
-    private static readonly HashSet<string> ContentHeaderNames = new(StringComparer.OrdinalIgnoreCase)
+    internal static readonly HashSet<string> ContentHeaderNames = new(StringComparer.OrdinalIgnoreCase)
     {
         "Allow",
         "Content-Disposition",
@@ -39,25 +39,25 @@ public class RequestMockResponseBuilder
     internal RequestMock RequestMock => requestMock;
 
     /// <summary>
-    /// Limits this mock to be used exactly once.
+    /// Limits the most recently configured response in the sequence to be used exactly once.
     /// </summary>
     public RequestMockResponseBuilder Once()
     {
-        requestMock.MaxInvocations = 1;
+        requestMock.SetCurrentResponseCount(1);
         return this;
     }
 
     /// <summary>
-    /// Limits this mock to be used exactly twice.
+    /// Limits the most recently configured response in the sequence to be used exactly twice.
     /// </summary>
     public RequestMockResponseBuilder Twice()
     {
-        requestMock.MaxInvocations = 2;
+        requestMock.SetCurrentResponseCount(2);
         return this;
     }
 
     /// <summary>
-    /// Limits this mock to be used exactly the specified number of times.
+    /// Limits the most recently configured response in the sequence to be used exactly the specified number of times.
     /// </summary>
     public RequestMockResponseBuilder Times(uint count)
     {
@@ -66,7 +66,7 @@ public class RequestMockResponseBuilder
             throw new ArgumentOutOfRangeException(nameof(count), count, "Cannot limit the number of mock invocations to less than 1");
         }
 
-        requestMock.MaxInvocations = count;
+        requestMock.SetCurrentResponseCount(count);
         return this;
     }
 
@@ -114,19 +114,12 @@ public class RequestMockResponseBuilder
 
         string[] capturedValues = [.. values];
 
-        Func<RequestInfo, HttpResponseMessage> existingResponder = requestMock.Responder;
-
-        requestMock.Responder = request =>
-        {
-            HttpResponseMessage response = existingResponder(request);
-            ApplyHeader(response, name, capturedValues);
-            return response;
-        };
+        requestMock.AppendResponseMutator(response => ApplyHeader(response, name, capturedValues));
 
         return this;
     }
 
-    private static void ApplyHeader(HttpResponseMessage response, string name, string[] values)
+    internal static void ApplyHeader(HttpResponseMessage response, string name, string[] values)
     {
         if (ContentHeaderNames.Contains(name))
         {
@@ -143,3 +136,4 @@ public class RequestMockResponseBuilder
         }
     }
 }
+

--- a/Mockly/ResponderFactory.cs
+++ b/Mockly/ResponderFactory.cs
@@ -1,0 +1,73 @@
+using System.Net;
+using System.Text;
+using System.Text.Json;
+#if NET472_OR_GREATER
+using System.Net.Http;
+#endif
+
+namespace Mockly;
+
+/// <summary>
+/// Centralizes the creation of responder functions used by both the initial <c>RespondsWith*</c> methods
+/// and the sequenced <c>Then*</c> methods.
+/// </summary>
+internal static class ResponderFactory
+{
+    public static Func<RequestInfo, HttpResponseMessage> Status(HttpStatusCode statusCode)
+    {
+        return _ => new HttpResponseMessage(statusCode);
+    }
+
+    public static Func<RequestInfo, HttpResponseMessage> JsonContent(HttpStatusCode statusCode, object content,
+        JsonSerializerOptions? options)
+    {
+        return _ =>
+        {
+            string json = JsonSerializer.Serialize(content, options);
+            return new HttpResponseMessage(statusCode)
+            {
+                Content = new StringContent(json, Encoding.UTF8, "application/json")
+            };
+        };
+    }
+
+    public static Func<RequestInfo, HttpResponseMessage> ODataResult(HttpStatusCode statusCode,
+        IEnumerable<object> value, string? odataContext, JsonSerializerOptions? options)
+    {
+        return _ =>
+        {
+            var payload = new Dictionary<string, object?>(StringComparer.Ordinal)
+            {
+                ["value"] = value.ToArray()
+            };
+
+            if (!string.IsNullOrWhiteSpace(odataContext))
+            {
+                payload["@odata.context"] = odataContext;
+            }
+
+            string json = JsonSerializer.Serialize(payload, options);
+            return new HttpResponseMessage(statusCode)
+            {
+                Content = new StringContent(json, Encoding.UTF8, "application/json")
+            };
+        };
+    }
+
+    public static Func<RequestInfo, HttpResponseMessage> Content(HttpStatusCode statusCode, string content,
+        string contentType)
+    {
+        return _ => new HttpResponseMessage(statusCode)
+        {
+            Content = new StringContent(content, Encoding.UTF8, contentType)
+        };
+    }
+
+    public static Func<RequestInfo, HttpResponseMessage> HttpContent(HttpStatusCode statusCode, HttpContent content)
+    {
+        return _ => new HttpResponseMessage(statusCode)
+        {
+            Content = content
+        };
+    }
+}

--- a/Mockly/SequencedResponseBuilder.cs
+++ b/Mockly/SequencedResponseBuilder.cs
@@ -1,0 +1,360 @@
+using System.Net;
+using System.Text.Json;
+#if NET472_OR_GREATER
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+#endif
+
+namespace Mockly;
+
+/// <summary>
+/// Fluent builder returned by every <c>RespondsWith*</c> method that lets you chain additional
+/// responses via <c>Then*</c> methods and configure per-response invocation counts via
+/// <see cref="Once"/>, <see cref="Twice"/>, and <see cref="Times"/>.
+/// </summary>
+/// <remarks>
+/// <c>Once()</c>, <c>Twice()</c>, and <c>Times(n)</c> apply to the response that was most recently
+/// configured. For example:
+/// <code>
+/// mock.ForGet("/api")
+///     .RespondsWithStatus(503).Once()       // 503 is returned once, then the sequence advances
+///     .ThenRespondsWithStatus(200).Twice()   // 200 is returned twice, then the mock is exhausted
+/// </code>
+/// When the last response in the sequence has no explicit count it repeats indefinitely;
+/// if it has an explicit count the mock becomes exhausted after that many invocations.
+/// </remarks>
+public class SequencedResponseBuilder : RequestMockResponseBuilder
+{
+    private readonly RequestMock requestMock;
+    private readonly JsonSerializerOptions? jsonSerializerOptions;
+
+    internal SequencedResponseBuilder(RequestMock requestMock, JsonSerializerOptions? jsonSerializerOptions = null)
+        : base(requestMock)
+    {
+        this.requestMock = requestMock;
+        this.jsonSerializerOptions = jsonSerializerOptions;
+    }
+
+    // ── Methods return SequencedResponseBuilder to keep the chain typed ───────────────────────
+    // These intentionally hide base class members with covariant return types.
+    // #pragma warning disable AV1010 is needed because the AV1010 rule flags all 'new' hiding,
+    // but this pattern is correct and intentional for a fluent builder that needs typed chaining.
+#pragma warning disable AV1010
+
+    /// <inheritdoc cref="RequestMockResponseBuilder.Once"/>
+    public new SequencedResponseBuilder Once()
+    {
+        base.Once();
+        return this;
+    }
+
+    /// <inheritdoc cref="RequestMockResponseBuilder.Twice"/>
+    public new SequencedResponseBuilder Twice()
+    {
+        base.Twice();
+        return this;
+    }
+
+    /// <inheritdoc cref="RequestMockResponseBuilder.Times"/>
+    public new SequencedResponseBuilder Times(uint count)
+    {
+        base.Times(count);
+        return this;
+    }
+
+    /// <inheritdoc cref="RequestMockResponseBuilder.WithHeader(string, string)"/>
+    public new SequencedResponseBuilder WithHeader(string name, string value)
+    {
+        return WithHeader(name, [value]);
+    }
+
+    /// <inheritdoc cref="RequestMockResponseBuilder.WithHeader(string, string[])"/>
+    public new SequencedResponseBuilder WithHeader(string name, params string[] values)
+    {
+        base.WithHeader(name, values);
+        return this;
+    }
+
+#pragma warning restore AV1010
+
+    // ── Sequence methods ──────────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Appends a response to the sequence that responds with the specified HTTP status code.
+    /// </summary>
+    /// <remarks>
+    /// Consecutive matching requests are served by consecutive responses in the order they were configured.
+    /// Once the last response's count (if set) is exhausted the mock stops matching; without an explicit
+    /// count the last response repeats indefinitely.
+    /// </remarks>
+    public SequencedResponseBuilder ThenRespondsWithStatus(HttpStatusCode statusCode)
+    {
+        requestMock.AppendResponder(ResponderFactory.Status(statusCode));
+        return this;
+    }
+
+    /// <summary>
+    /// Appends a response to the sequence that uses the specified custom responder function.
+    /// </summary>
+    /// <remarks>
+    /// Consecutive matching requests are served by consecutive responses in the order they were configured.
+    /// Once the last response's count (if set) is exhausted the mock stops matching; without an explicit
+    /// count the last response repeats indefinitely.
+    /// </remarks>
+    public SequencedResponseBuilder ThenRespondsWith(Func<RequestInfo, HttpResponseMessage> responder)
+    {
+        requestMock.AppendResponder(responder);
+        return this;
+    }
+
+    /// <summary>
+    /// Appends a response to the sequence using a custom asynchronous responder function.
+    /// </summary>
+    /// <param name="responder">An asynchronous function that produces the response for a matching request.</param>
+    /// <remarks>
+    /// Consecutive matching requests are served by consecutive responses in the order they were configured.
+    /// Once the last response's count (if set) is exhausted the mock stops matching; without an explicit
+    /// count the last response repeats indefinitely.
+    /// </remarks>
+    public SequencedResponseBuilder ThenRespondsWith(Func<RequestInfo, Task<HttpResponseMessage>> responder)
+    {
+        if (responder is null)
+        {
+            throw new ArgumentNullException(nameof(responder));
+        }
+
+        return ThenRespondsWith((request, _) => responder(request));
+    }
+
+    /// <summary>
+    /// Appends a response to the sequence using a custom asynchronous responder function that receives the
+    /// <see cref="CancellationToken"/> flowing from the HTTP pipeline.
+    /// </summary>
+    /// <param name="responder">
+    /// An asynchronous function that produces the response for a matching request, observing the supplied
+    /// <see cref="CancellationToken"/>.
+    /// </param>
+    /// <remarks>
+    /// Consecutive matching requests are served by consecutive responses in the order they were configured.
+    /// Once the last response's count (if set) is exhausted the mock stops matching; without an explicit
+    /// count the last response repeats indefinitely.
+    /// </remarks>
+    public SequencedResponseBuilder ThenRespondsWith(Func<RequestInfo, CancellationToken, Task<HttpResponseMessage>> responder)
+    {
+        if (responder is null)
+        {
+            throw new ArgumentNullException(nameof(responder));
+        }
+
+        requestMock.AppendAsyncResponder(responder);
+        return this;
+    }
+
+    /// <summary>
+    /// Appends a response to the sequence that responds with the specified HTTP content and status code 200 (OK).
+    /// </summary>
+    /// <param name="content">The HTTP content to include in the response.</param>
+    /// <remarks>
+    /// Note: The same <paramref name="content"/> instance is reused every time this response is served, including when
+    /// it is the last response in the sequence and repeats. If the response will be served multiple times, consider
+    /// using the <see cref="ThenRespondsWith(Func{RequestInfo, HttpResponseMessage})"/> overload to create a new
+    /// content instance for each request.
+    /// </remarks>
+    public SequencedResponseBuilder ThenRespondsWith(HttpContent content)
+    {
+        return ThenRespondsWith(HttpStatusCode.OK, content);
+    }
+
+    /// <summary>
+    /// Appends a response to the sequence that responds with the specified HTTP content and status code.
+    /// </summary>
+    /// <param name="statusCode">The HTTP status code for the response.</param>
+    /// <param name="content">The HTTP content to include in the response.</param>
+    /// <remarks>
+    /// Note: The same <paramref name="content"/> instance is reused every time this response is served, including when
+    /// it is the last response in the sequence and repeats. If the response will be served multiple times, consider
+    /// using the <see cref="ThenRespondsWith(Func{RequestInfo, HttpResponseMessage})"/> overload to create a new
+    /// content instance for each request.
+    /// </remarks>
+    public SequencedResponseBuilder ThenRespondsWith(HttpStatusCode statusCode, HttpContent content)
+    {
+        requestMock.AppendResponder(ResponderFactory.HttpContent(statusCode, content));
+        return this;
+    }
+
+    /// <summary>
+    /// Appends a response to the sequence with JSON content serialized from the specified object and status code 200 (OK).
+    /// </summary>
+    public SequencedResponseBuilder ThenRespondsWithJsonContent(object content)
+    {
+        return ThenRespondsWithJsonContent(HttpStatusCode.OK, content);
+    }
+
+    /// <summary>
+    /// Appends a response to the sequence with JSON content serialized from the object built by the specified builder and status code 200 (OK).
+    /// </summary>
+    /// <typeparam name="T">The type of object to build and serialize.</typeparam>
+    /// <param name="builder">The builder that will construct the object to serialize.</param>
+    public SequencedResponseBuilder ThenRespondsWithJsonContent<T>(IResponseBuilder<T> builder)
+    {
+        return ThenRespondsWithJsonContent(HttpStatusCode.OK, builder);
+    }
+
+    /// <summary>
+    /// Appends a response to the sequence with JSON content serialized from the specified object and a specific status code.
+    /// </summary>
+    public SequencedResponseBuilder ThenRespondsWithJsonContent(HttpStatusCode statusCode, object content)
+    {
+        requestMock.AppendResponder(ResponderFactory.JsonContent(statusCode, content, jsonSerializerOptions));
+        return this;
+    }
+
+    /// <summary>
+    /// Appends a response to the sequence with JSON content serialized from the object built by the specified builder and a specific status code.
+    /// </summary>
+    /// <typeparam name="T">The type of object to build and serialize.</typeparam>
+    /// <param name="statusCode">The HTTP status code to respond with.</param>
+    /// <param name="builder">The builder that will construct the object to serialize.</param>
+    public SequencedResponseBuilder ThenRespondsWithJsonContent<T>(HttpStatusCode statusCode, IResponseBuilder<T> builder)
+    {
+        object content = builder.Build()!;
+        return ThenRespondsWithJsonContent(statusCode, content);
+    }
+
+    /// <summary>
+    /// Appends a response to the sequence with an OData v4 result envelope containing a single entity and status code 200 (OK).
+    /// </summary>
+    /// <param name="value">The entity to include in the OData result.</param>
+    public SequencedResponseBuilder ThenRespondsWithODataResult(object value)
+    {
+        return ThenRespondsWithODataResult(HttpStatusCode.OK, [value]);
+    }
+
+    /// <summary>
+    /// Appends a response to the sequence with an OData v4 result envelope containing a single entity built by the specified builder and status code 200 (OK).
+    /// </summary>
+    /// <typeparam name="T">The type of entity to build.</typeparam>
+    /// <param name="builder">The builder that will construct the entity to include in the OData result.</param>
+    public SequencedResponseBuilder ThenRespondsWithODataResult<T>(IResponseBuilder<T> builder)
+    {
+        return ThenRespondsWithODataResult(HttpStatusCode.OK, builder);
+    }
+
+    /// <summary>
+    /// Appends a response to the sequence with an OData v4 result envelope containing a single entity.
+    /// </summary>
+    /// <param name="statusCode">The HTTP status code for the response.</param>
+    /// <param name="value">The entity to include in the OData result.</param>
+    public SequencedResponseBuilder ThenRespondsWithODataResult(HttpStatusCode statusCode, object value)
+    {
+        return ThenRespondsWithODataResult(statusCode, [value]);
+    }
+
+    /// <summary>
+    /// Appends a response to the sequence with an OData v4 result envelope containing a single entity built by the specified builder.
+    /// </summary>
+    /// <typeparam name="T">The type of entity to build.</typeparam>
+    /// <param name="statusCode">The HTTP status code for the response.</param>
+    /// <param name="builder">The builder that will construct the entity to include in the OData result.</param>
+    public SequencedResponseBuilder ThenRespondsWithODataResult<T>(HttpStatusCode statusCode, IResponseBuilder<T> builder)
+    {
+        object value = builder.Build()!;
+        return ThenRespondsWithODataResult(statusCode, value);
+    }
+
+    /// <summary>
+    /// Appends a response to the sequence with an OData v4 result envelope: { "value": [...] } and status code 200 (OK).
+    /// </summary>
+    public SequencedResponseBuilder ThenRespondsWithODataResult(IEnumerable<object> value)
+    {
+        return ThenRespondsWithODataResult(HttpStatusCode.OK, value);
+    }
+
+    /// <summary>
+    /// Appends a response to the sequence with an OData v4 result envelope containing entities built by the specified builders and status code 200 (OK).
+    /// </summary>
+    /// <typeparam name="T">The type of entities to build.</typeparam>
+    /// <param name="builders">The builders that will construct the entities to include in the OData result.</param>
+    public SequencedResponseBuilder ThenRespondsWithODataResult<T>(IEnumerable<IResponseBuilder<T>> builders)
+    {
+        return ThenRespondsWithODataResult(HttpStatusCode.OK, builders);
+    }
+
+    /// <summary>
+    /// Appends a response to the sequence with an OData v4 result envelope: { "value": [...] } and a specific status code.
+    /// </summary>
+    public SequencedResponseBuilder ThenRespondsWithODataResult(HttpStatusCode statusCode, IEnumerable<object> value)
+    {
+        requestMock.AppendResponder(ResponderFactory.ODataResult(statusCode, value, odataContext: null, jsonSerializerOptions));
+        return this;
+    }
+
+    /// <summary>
+    /// Appends a response to the sequence with an OData v4 result envelope containing entities built by the specified builders and a specific status code.
+    /// </summary>
+    /// <typeparam name="T">The type of entities to build.</typeparam>
+    /// <param name="statusCode">The HTTP status code for the response.</param>
+    /// <param name="builders">The builders that will construct the entities to include in the OData result.</param>
+    public SequencedResponseBuilder ThenRespondsWithODataResult<T>(HttpStatusCode statusCode, IEnumerable<IResponseBuilder<T>> builders)
+    {
+        var builtValues = builders.Select(b => b.Build()).Cast<object>();
+        return ThenRespondsWithODataResult(statusCode, builtValues);
+    }
+
+    /// <summary>
+    /// Appends a response to the sequence with an OData v4 result envelope including the optional "@odata.context" value.
+    /// </summary>
+    public SequencedResponseBuilder ThenRespondsWithODataResult(HttpStatusCode statusCode, IEnumerable<object> value,
+        string odataContext)
+    {
+        requestMock.AppendResponder(ResponderFactory.ODataResult(statusCode, value, odataContext, jsonSerializerOptions));
+        return this;
+    }
+
+    /// <summary>
+    /// Appends a response to the sequence with an OData v4 result envelope containing entities built by the specified builders and including the optional "@odata.context" value.
+    /// </summary>
+    /// <typeparam name="T">The type of entities to build.</typeparam>
+    /// <param name="statusCode">The HTTP status code for the response.</param>
+    /// <param name="builders">The builders that will construct the entities to include in the OData result.</param>
+    /// <param name="odataContext">The OData context URL to include in the response.</param>
+    public SequencedResponseBuilder ThenRespondsWithODataResult<T>(HttpStatusCode statusCode,
+        IEnumerable<IResponseBuilder<T>> builders, string odataContext)
+    {
+        var builtValues = builders.Select(b => b.Build()).Cast<object>();
+        return ThenRespondsWithODataResult(statusCode, builtValues, odataContext);
+    }
+
+    /// <summary>
+    /// Appends a response to the sequence with the specified raw string content, status code 200 (OK), and content type "application/json".
+    /// </summary>
+    /// <param name="content">The body content to return in the HTTP response.</param>
+    public SequencedResponseBuilder ThenRespondsWithContent(string content)
+    {
+        return ThenRespondsWithContent(HttpStatusCode.OK, content);
+    }
+
+    /// <summary>
+    /// Appends a response to the sequence with a specific HTTP status code, content, and content type.
+    /// </summary>
+    /// <param name="statusCode">The HTTP status code to respond with.</param>
+    /// <param name="content">The response content as a string.</param>
+    /// <param name="contentType">The MIME type of the response content.</param>
+    public SequencedResponseBuilder ThenRespondsWithContent(HttpStatusCode statusCode, string content,
+        string contentType = "application/json")
+    {
+        requestMock.AppendResponder(ResponderFactory.Content(statusCode, content, contentType));
+        return this;
+    }
+
+    /// <summary>
+    /// Appends a response to the sequence with empty content.
+    /// </summary>
+    public SequencedResponseBuilder ThenRespondsWithEmptyContent(HttpStatusCode statusCode = HttpStatusCode.NoContent)
+    {
+        requestMock.AppendResponder(ResponderFactory.Status(statusCode));
+        return this;
+    }
+}
+

--- a/README.md
+++ b/README.md
@@ -192,6 +192,19 @@ mock.Requests.Should().ContainRequestFor("https://api.example.com/*")
 * Custom response generators
 * OData support
 
+### 🔁 Sequenced Responses
+
+Configure a sequence of responses for the same matched request so consecutive calls get different responses (e.g. the classic "fail twice, then succeed" retry test). Chain `Then(...)` after any `RespondsWith*` method. The last response repeats for any calls beyond the configured sequence.
+
+```csharp
+mock.ForGet().WithPath("/resource")
+    .RespondsWithStatus(HttpStatusCode.ServiceUnavailable)
+    .Then(HttpStatusCode.ServiceUnavailable)
+    .Then(HttpStatusCode.OK);
+```
+
+The `Then*` family mirrors the `RespondsWith*` methods (`ThenRespondsWithJsonContent`, `ThenRespondsWithContent`, `ThenRespondsWithODataResult`, and `Then(Func<RequestInfo, HttpResponseMessage>)`).
+
 ### 🛡️ Fail-Fast Testing
 
 ```csharp

--- a/website/docs/advanced.md
+++ b/website/docs/advanced.md
@@ -170,6 +170,7 @@ mock.ForDelete()
 - Exhausted mocks are skipped when matching. If no other non-exhausted mock matches and `FailOnUnexpectedCalls` is `true` (default), an `UnexpectedRequestException` is thrown.
 - The mocks are evaluated in the order they were created.
 - The default for mocks without limits is unlimited invocations
+- Invocation limits and sequenced responses are independent. A `Times(2)` mock with three configured responses still stops matching after the second call.
 - The verification helpers consider limits:
   - `HttpMock.AllMocksInvoked` returns `true` only when each mock has been called at least once or has reached its configured `Times(..)` limit.
   - `HttpMock.GetUninvokedMocks()` lists mocks that haven't reached their required count (or have 0 calls for unlimited mocks).

--- a/website/docs/intro.md
+++ b/website/docs/intro.md
@@ -30,6 +30,7 @@ Unlike other HTTP mocking libraries, Mockly offers:
 * **Zero configuration** - Works out of the box with sensible defaults
 * **Performance optimized** - Regex patterns are cached for efficient matching
 * **Invocation limits** - Restrict how many times a mock can respond using `Once()`, `Twice()`, or `Times(n)`
+* **Sequenced responses** - Return different responses over consecutive calls by chaining `Then(...)`
 
 ## Who created this?
 
@@ -107,6 +108,19 @@ mock.Requests.Should().ContainRequestForUrl("http://localhost:7021/api/*")
 * Custom HTTP status codes
 * Custom response generators
 * OData support
+
+### 🔁 Sequenced Responses
+
+Configure a sequence of responses for the same matched request so consecutive calls can return different results (for example, "fail twice, then succeed" retry scenarios).
+
+```csharp
+mock.ForGet().WithPath("/resource")
+    .RespondsWithStatus(HttpStatusCode.ServiceUnavailable)
+    .Then(HttpStatusCode.ServiceUnavailable)
+    .Then(HttpStatusCode.OK);
+```
+
+Any calls after the configured sequence reuse the last response.
 
 ### 🛡️ Fail-Fast Testing
 

--- a/website/docs/usage.md
+++ b/website/docs/usage.md
@@ -335,6 +335,25 @@ mock.ForGet()
     });
 ```
 
+### Sequenced Responses
+
+Configure a sequence of responses for the same matched request so consecutive calls get different results:
+
+```csharp
+mock.ForGet()
+    .WithPath("/api/resource")
+    .RespondsWithStatus(HttpStatusCode.ServiceUnavailable)
+    .Then(HttpStatusCode.ServiceUnavailable)
+    .Then(HttpStatusCode.OK);
+```
+
+`Then*` mirrors the `RespondsWith*` response methods, including JSON/content/OData variants and custom delegates (`Then(Func<RequestInfo, HttpResponseMessage>)`).
+
+Behavior notes:
+
+- After the configured sequence is exhausted, the last response is reused.
+- Sequence length is independent from invocation limits (`Once()`, `Twice()`, `Times(n)`).
+
 ## Using Test Data Builders
 
 Mockly supports the `IResponseBuilder<T>` interface, allowing you to integrate test data builders seamlessly:


### PR DESCRIPTION
Closes #115

## Summary

Adds support for configuring a sequence of responses for the same matched request, so consecutive calls get different responses (the classic "fail twice, then succeed" retry test, or paging). Chain `Then(...)` after any `RespondsWith*` method; the last response repeats for any calls beyond the configured sequence.

```csharp
mock.ForGet().WithPath("/resource")
    .RespondsWithStatus(HttpStatusCode.ServiceUnavailable)
    .Then(HttpStatusCode.ServiceUnavailable)
    .Then(HttpStatusCode.OK);
```

## Implementation

- `RequestMock` now holds an ordered `List<Func<RequestInfo, HttpResponseMessage>>` of responders. The public `Responder` property is unchanged in type and continues to represent the first/only responder (backed by `responders[0]` under a lock), so existing get/set usage is preserved.
- `TrackRequest` selects the responder by invocation index and repeats the last entry once the sequence is exhausted. A new internal `AppendResponder` adds to the list.
- New internal `ResponderFactory` centralizes building of response funcs (status, JSON, OData, content, HTTP content), shared by both `RespondsWith*` and `Then*` to avoid duplication.
- `RequestMockBuilder` leaf methods refactored onto a single `CreateResponse(responder)` helper.

## New public API (additive, backward-compatible)

On `RequestMockResponseBuilder`:

- `Then(HttpStatusCode)`
- `Then(Func<RequestInfo, HttpResponseMessage>)`
- `Then(HttpContent)` / `Then(HttpStatusCode, HttpContent)`
- `ThenRespondsWithJsonContent(...)` (object / `IResponseBuilder<T>` / status-code overloads)
- `ThenRespondsWithContent(...)`
- `ThenRespondsWithEmptyContent(...)`
- `ThenRespondsWithODataResult(...)` (entity / collection / builder / `@odata.context` overloads)

`RequestMock.Responder` is intentionally left as the canonical single/first responder (type unchanged) so existing usage keeps working.

## Behavior notes

- Sequence length and `Times(n)`/`MaxInvocations` are **independent**. With `Times(2)` and a 2-entry sequence, the mock stops matching after 2 invocations and a 3rd call throws `UnexpectedRequestException`.
- The last configured response repeats for any subsequent matching calls.

## Tests

Added a `SequencedResponses` spec class covering: sequence advances per call, last response repeats, single response still repeats, sequenced JSON bodies differ, combined with `CollectingRequestsIn`, combined with `Times(n)`, appending a custom responder, and that `Responder` still exposes the first response.

## Verification

- `dotnet test` green on **net8.0** (95) and **net472** (94).
- API verification tests regenerated via `AcceptApiChanges.ps1`; `*.verified.txt` updated and passing.
- Analyzers (StyleCop, CSharpGuidelinesAnalyzer, Roslynator, Meziantou) pass with warnings-as-errors.

Do not merge — draft for maintainer review.