### PR TITLE
Add ImportFromCurl to bootstrap a mock from an existing curl command

### DIFF
--- a/Mockly.ApiVerificationTests/ApprovedApi/net472.verified.txt
+++ b/Mockly.ApiVerificationTests/ApprovedApi/net472.verified.txt
@@ -52,6 +52,7 @@ namespace Mockly
         public System.Net.Http.IHttpClientFactory GetClientFactory() { }
         public System.Net.Http.HttpMessageHandler GetMessageHandler() { }
         public System.Collections.Generic.IEnumerable<Mockly.RequestMock> GetUninvokedMocks() { }
+        public Mockly.RequestMockBuilder ImportFromCurl(string curlCommand) { }
         public Mockly.HttpMock Reset() { }
     }
     public interface IResponseBuilder<out T>

--- a/Mockly.ApiVerificationTests/ApprovedApi/net472.verified.txt
+++ b/Mockly.ApiVerificationTests/ApprovedApi/net472.verified.txt
@@ -44,6 +44,7 @@ namespace Mockly
         public System.Net.Http.IHttpClientFactory GetClientFactory() { }
         public System.Net.Http.HttpMessageHandler GetMessageHandler() { }
         public System.Collections.Generic.IEnumerable<Mockly.RequestMock> GetUninvokedMocks() { }
+        public Mockly.RequestMockBuilder ImportFromCurl(string curlCommand) { }
         public Mockly.HttpMock Reset() { }
     }
     public interface IResponseBuilder<out T>

--- a/Mockly.ApiVerificationTests/ApprovedApi/net8.0.verified.txt
+++ b/Mockly.ApiVerificationTests/ApprovedApi/net8.0.verified.txt
@@ -46,6 +46,7 @@ namespace Mockly
         public System.Net.Http.IHttpClientFactory GetClientFactory() { }
         public System.Net.Http.HttpMessageHandler GetMessageHandler() { }
         public System.Collections.Generic.IEnumerable<Mockly.RequestMock> GetUninvokedMocks() { }
+        public Mockly.RequestMockBuilder ImportFromCurl(string curlCommand) { }
         public Mockly.HttpMock Reset() { }
     }
     public interface IResponseBuilder<out T>

--- a/Mockly.ApiVerificationTests/ApprovedApi/net8.0.verified.txt
+++ b/Mockly.ApiVerificationTests/ApprovedApi/net8.0.verified.txt
@@ -54,6 +54,7 @@ namespace Mockly
         public System.Net.Http.IHttpClientFactory GetClientFactory() { }
         public System.Net.Http.HttpMessageHandler GetMessageHandler() { }
         public System.Collections.Generic.IEnumerable<Mockly.RequestMock> GetUninvokedMocks() { }
+        public Mockly.RequestMockBuilder ImportFromCurl(string curlCommand) { }
         public Mockly.HttpMock Reset() { }
     }
     public interface IResponseBuilder<out T>

--- a/Mockly.Specs/CurlImportSpecs.cs
+++ b/Mockly.Specs/CurlImportSpecs.cs
@@ -1,0 +1,404 @@
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Xunit;
+
+namespace Mockly.Specs;
+
+public class CurlImportSpecs
+{
+    public class BasicRequests
+    {
+        [Fact]
+        public async Task Can_import_a_simple_get_request()
+        {
+            // Arrange
+            var mock = new HttpMock();
+            mock.ImportFromCurl("curl https://api.example.com/users")
+                .RespondsWithStatus(HttpStatusCode.OK);
+
+            // Act
+            var response = await mock.GetClient().GetAsync("https://api.example.com/users");
+
+            // Assert
+            response.Should().Be200Ok();
+        }
+
+        [Fact]
+        public async Task Can_import_a_request_without_the_curl_executable_prefix()
+        {
+            // Arrange
+            var mock = new HttpMock();
+            mock.ImportFromCurl("https://api.example.com/users")
+                .RespondsWithStatus(HttpStatusCode.OK);
+
+            // Act
+            var response = await mock.GetClient().GetAsync("https://api.example.com/users");
+
+            // Assert
+            response.Should().Be200Ok();
+        }
+
+        [Fact]
+        public async Task Preserves_the_query_string()
+        {
+            // Arrange
+            var mock = new HttpMock();
+            mock.ImportFromCurl("curl 'https://api.example.com/search?q=mockly&page=2'")
+                .RespondsWithStatus(HttpStatusCode.OK);
+
+            // Act
+            var response = await mock.GetClient().GetAsync("https://api.example.com/search?q=mockly&page=2");
+
+            // Assert
+            response.Should().Be200Ok();
+        }
+
+        [Fact]
+        public async Task A_request_without_the_expected_query_string_is_not_matched()
+        {
+            // Arrange
+            var mock = new HttpMock();
+            mock.ImportFromCurl("curl 'https://api.example.com/search?q=mockly'")
+                .RespondsWithStatus(HttpStatusCode.OK);
+
+            // Act
+            var act = () => mock.GetClient().GetAsync("https://api.example.com/search");
+
+            // Assert
+            await act.Should().ThrowAsync<UnexpectedRequestException>();
+        }
+
+        [Fact]
+        public async Task Honors_the_scheme_from_the_url()
+        {
+            // Arrange
+            var mock = new HttpMock();
+            mock.ImportFromCurl("curl http://api.example.com/users")
+                .RespondsWithStatus(HttpStatusCode.OK);
+
+            // Act
+            var act = () => mock.GetClient().GetAsync("https://api.example.com/users");
+
+            // Assert
+            await act.Should().ThrowAsync<UnexpectedRequestException>();
+        }
+    }
+
+    public class Methods
+    {
+        [Fact]
+        public async Task Uses_the_explicit_method_from_the_dash_x_option()
+        {
+            // Arrange
+            var mock = new HttpMock();
+            mock.ImportFromCurl("curl -X DELETE https://api.example.com/users/1")
+                .RespondsWithStatus(HttpStatusCode.NoContent);
+
+            // Act
+            var response = await mock.GetClient().DeleteAsync("https://api.example.com/users/1");
+
+            // Assert
+            response.StatusCode.Should().Be(HttpStatusCode.NoContent);
+        }
+
+        [Fact]
+        public async Task Normalizes_a_lowercase_method_name()
+        {
+            // Arrange
+            var mock = new HttpMock();
+            mock.ImportFromCurl("curl -X post https://api.example.com/users -d 'name=mockly'")
+                .RespondsWithStatus(HttpStatusCode.Created);
+
+            // Act
+            var content = new StringContent("name=mockly");
+            var response = await mock.GetClient().PostAsync("https://api.example.com/users", content);
+
+            // Assert
+            response.StatusCode.Should().Be(HttpStatusCode.Created);
+        }
+
+        [Fact]
+        public async Task Defaults_to_post_when_a_body_is_present_without_an_explicit_method()
+        {
+            // Arrange
+            var mock = new HttpMock();
+            mock.ImportFromCurl("curl https://api.example.com/users --data 'name=mockly'")
+                .RespondsWithStatus(HttpStatusCode.Created);
+
+            // Act
+            var content = new StringContent("name=mockly");
+            var response = await mock.GetClient().PostAsync("https://api.example.com/users", content);
+
+            // Assert
+            response.StatusCode.Should().Be(HttpStatusCode.Created);
+        }
+    }
+
+    public class RequestHeaders
+    {
+        [Fact]
+        public async Task Matches_a_single_request_header()
+        {
+            // Arrange
+            var mock = new HttpMock();
+            mock.ImportFromCurl("curl https://api.example.com/users -H 'Accept: application/json'")
+                .RespondsWithStatus(HttpStatusCode.OK);
+
+            // Act
+            var request = new HttpRequestMessage(HttpMethod.Get, "https://api.example.com/users");
+            request.Headers.Add("Accept", "application/json");
+            var response = await mock.GetClient().SendAsync(request);
+
+            // Assert
+            response.Should().Be200Ok();
+        }
+
+        [Fact]
+        public async Task Matches_multiple_request_headers()
+        {
+            // Arrange
+            var mock = new HttpMock();
+            mock.ImportFromCurl(
+                    "curl https://api.example.com/users -H 'Accept: application/json' -H 'Authorization: Bearer abc123'")
+                .RespondsWithStatus(HttpStatusCode.OK);
+
+            // Act
+            var request = new HttpRequestMessage(HttpMethod.Get, "https://api.example.com/users");
+            request.Headers.Add("Accept", "application/json");
+            request.Headers.Add("Authorization", "Bearer abc123");
+            var response = await mock.GetClient().SendAsync(request);
+
+            // Assert
+            response.Should().Be200Ok();
+        }
+
+        [Fact]
+        public async Task A_request_missing_a_required_header_is_not_matched()
+        {
+            // Arrange
+            var mock = new HttpMock();
+            mock.ImportFromCurl("curl https://api.example.com/users -H 'Authorization: Bearer abc123'")
+                .RespondsWithStatus(HttpStatusCode.OK);
+
+            // Act
+            var act = () => mock.GetClient().GetAsync("https://api.example.com/users");
+
+            // Assert
+            await act.Should().ThrowAsync<UnexpectedRequestException>();
+        }
+    }
+
+    public class Bodies
+    {
+        [Fact]
+        public async Task Matches_a_json_body_ignoring_whitespace()
+        {
+            // Arrange
+            var mock = new HttpMock();
+            mock.ImportFromCurl(
+                    "curl -X POST https://api.example.com/users -H 'Content-Type: application/json' " +
+                    "--data-raw '{\"name\":\"mockly\"}'")
+                .RespondsWithStatus(HttpStatusCode.Created);
+
+            // Act
+            var content = new StringContent("{\n  \"name\": \"mockly\"\n}", Encoding.UTF8, "application/json");
+            var response = await mock.GetClient().PostAsync("https://api.example.com/users", content);
+
+            // Assert
+            response.StatusCode.Should().Be(HttpStatusCode.Created);
+        }
+
+        [Fact]
+        public async Task A_request_with_a_different_json_body_is_not_matched()
+        {
+            // Arrange
+            var mock = new HttpMock();
+            mock.ImportFromCurl(
+                    "curl -X POST https://api.example.com/users -H 'Content-Type: application/json' " +
+                    "--data-raw '{\"name\":\"mockly\"}'")
+                .RespondsWithStatus(HttpStatusCode.Created);
+
+            // Act
+            var content = new StringContent("{\"name\":\"other\"}", Encoding.UTF8, "application/json");
+            var act = () => mock.GetClient().PostAsync("https://api.example.com/users", content);
+
+            // Assert
+            await act.Should().ThrowAsync<UnexpectedRequestException>();
+        }
+
+        [Fact]
+        public async Task Matches_a_form_encoded_body()
+        {
+            // Arrange
+            var mock = new HttpMock();
+            mock.ImportFromCurl("curl -X POST https://api.example.com/login -d 'user=admin&password=secret'")
+                .RespondsWithStatus(HttpStatusCode.OK);
+
+            // Act
+            var content = new StringContent("user=admin&password=secret");
+            var response = await mock.GetClient().PostAsync("https://api.example.com/login", content);
+
+            // Assert
+            response.Should().Be200Ok();
+        }
+
+        [Fact]
+        public async Task A_non_json_body_is_matched_exactly_and_not_as_a_substring()
+        {
+            // Arrange
+            var mock = new HttpMock();
+            mock.ImportFromCurl("curl -X POST https://api.example.com/login -d 'user=admin'")
+                .RespondsWithStatus(HttpStatusCode.OK);
+
+            // Act
+            var content = new StringContent("user=admin&extra=1");
+            var act = () => mock.GetClient().PostAsync("https://api.example.com/login", content);
+
+            // Assert
+            await act.Should().ThrowAsync<UnexpectedRequestException>();
+        }
+    }
+
+    public class ShellSyntax
+    {
+        [Fact]
+        public async Task Supports_backslash_line_continuations()
+        {
+            // Arrange
+            var mock = new HttpMock();
+            var curl =
+                "curl 'https://api.example.com/users' \\\n" +
+                "  -H 'Accept: application/json'";
+
+            mock.ImportFromCurl(curl).RespondsWithStatus(HttpStatusCode.OK);
+
+            // Act
+            var request = new HttpRequestMessage(HttpMethod.Get, "https://api.example.com/users");
+            request.Headers.Add("Accept", "application/json");
+            var response = await mock.GetClient().SendAsync(request);
+
+            // Assert
+            response.Should().Be200Ok();
+        }
+
+        [Fact]
+        public async Task Supports_double_quoted_arguments()
+        {
+            // Arrange
+            var mock = new HttpMock();
+            mock.ImportFromCurl("curl \"https://api.example.com/users\" -H \"Accept: application/json\"")
+                .RespondsWithStatus(HttpStatusCode.OK);
+
+            // Act
+            var request = new HttpRequestMessage(HttpMethod.Get, "https://api.example.com/users");
+            request.Headers.Add("Accept", "application/json");
+            var response = await mock.GetClient().SendAsync(request);
+
+            // Assert
+            response.Should().Be200Ok();
+        }
+    }
+
+    public class OptionParsing
+    {
+        [Fact]
+        public async Task Ignores_options_with_values_so_they_are_not_treated_as_the_url()
+        {
+            // Arrange
+            var mock = new HttpMock();
+            mock.ImportFromCurl("curl -u user:pass https://api.example.com/users")
+                .RespondsWithStatus(HttpStatusCode.OK);
+
+            // Act
+            var response = await mock.GetClient().GetAsync("https://api.example.com/users");
+
+            // Assert
+            response.Should().Be200Ok();
+        }
+    }
+
+    public class MalformedInput
+    {
+        [Fact]
+        public void A_null_command_throws()
+        {
+            // Arrange
+            var mock = new HttpMock();
+
+            // Act
+            var act = () => mock.ImportFromCurl(null!);
+
+            // Assert
+            act.Should().Throw<ArgumentNullException>();
+        }
+
+        [Fact]
+        public void An_empty_command_throws_a_clear_exception()
+        {
+            // Arrange
+            var mock = new HttpMock();
+
+            // Act
+            var act = () => mock.ImportFromCurl("   ");
+
+            // Assert
+            act.Should().Throw<ArgumentException>().WithMessage("*empty*");
+        }
+
+        [Fact]
+        public void A_command_without_a_url_throws_a_clear_exception()
+        {
+            // Arrange
+            var mock = new HttpMock();
+
+            // Act
+            var act = () => mock.ImportFromCurl("curl -X GET");
+
+            // Assert
+            act.Should().Throw<ArgumentException>().WithMessage("*does not contain a URL*");
+        }
+
+        [Fact]
+        public void An_option_missing_its_value_throws_a_clear_exception()
+        {
+            // Arrange
+            var mock = new HttpMock();
+
+            // Act
+            var act = () => mock.ImportFromCurl("curl https://api.example.com/users -H");
+
+            // Assert
+            act.Should().Throw<ArgumentException>().WithMessage("*missing a value*");
+        }
+
+        [Fact]
+        public void An_unterminated_quote_throws_a_clear_exception()
+        {
+            // Arrange
+            var mock = new HttpMock();
+
+            // Act
+            var act = () => mock.ImportFromCurl("curl 'https://api.example.com/users");
+
+            // Assert
+            act.Should().Throw<ArgumentException>().WithMessage("*unterminated*");
+        }
+
+        [Fact]
+        public void A_malformed_header_throws_a_clear_exception()
+        {
+            // Arrange
+            var mock = new HttpMock();
+
+            // Act
+            var act = () => mock.ImportFromCurl("curl https://api.example.com/users -H 'NotAHeader'");
+
+            // Assert
+            act.Should().Throw<ArgumentException>().WithMessage("*Name: Value*");
+        }
+    }
+}

--- a/Mockly.Specs/CurlImportSpecs.cs
+++ b/Mockly.Specs/CurlImportSpecs.cs
@@ -13,7 +13,7 @@ public class CurlImportSpecs
     public class BasicRequests
     {
         [Fact]
-        public async Task Can_import_a_simple_get_request()
+        public async Task Imports_a_simple_get_request()
         {
             // Arrange
             var mock = new HttpMock();
@@ -28,7 +28,7 @@ public class CurlImportSpecs
         }
 
         [Fact]
-        public async Task Can_import_a_request_without_the_curl_executable_prefix()
+        public async Task Imports_a_request_without_the_curl_executable_prefix()
         {
             // Arrange
             var mock = new HttpMock();
@@ -82,6 +82,51 @@ public class CurlImportSpecs
 
             // Act
             var act = () => mock.GetClient().GetAsync("https://api.example.com/users");
+
+            // Assert
+            await act.Should().ThrowAsync<UnexpectedRequestException>();
+        }
+
+        [Fact]
+        public async Task Defaults_to_http_when_the_url_has_no_scheme()
+        {
+            // Arrange
+            var mock = new HttpMock();
+            mock.ImportFromCurl("curl api.example.com/users")
+                .RespondsWithStatus(HttpStatusCode.OK);
+
+            // Act
+            var act = () => mock.GetClient().GetAsync("https://api.example.com/users");
+
+            // Assert
+            await act.Should().ThrowAsync<UnexpectedRequestException>();
+        }
+
+        [Fact]
+        public async Task Matches_a_url_encoded_query_value_against_the_decoded_request_query()
+        {
+            // Arrange
+            var mock = new HttpMock();
+            mock.ImportFromCurl("curl 'https://api.example.com/search?q=hello%20world'")
+                .RespondsWithStatus(HttpStatusCode.OK);
+
+            // Act
+            var response = await mock.GetClient().GetAsync("https://api.example.com/search?q=hello%20world");
+
+            // Assert
+            response.Should().Be200Ok();
+        }
+
+        [Fact]
+        public async Task Treats_a_literal_asterisk_in_the_path_as_a_literal_character()
+        {
+            // Arrange
+            var mock = new HttpMock();
+            mock.ImportFromCurl("curl 'https://api.example.com/users/*'")
+                .RespondsWithStatus(HttpStatusCode.OK);
+
+            // Act
+            var act = () => mock.GetClient().GetAsync("https://api.example.com/users/1");
 
             // Assert
             await act.Should().ThrowAsync<UnexpectedRequestException>();
@@ -190,6 +235,72 @@ public class CurlImportSpecs
             // Assert
             await act.Should().ThrowAsync<UnexpectedRequestException>();
         }
+
+        [Fact]
+        public async Task Matches_a_multi_token_header_by_its_original_separator()
+        {
+            // Arrange
+            var mock = new HttpMock();
+            mock.ImportFromCurl("curl https://api.example.com/users -A 'Mozilla/5.0 Foo/1.0'")
+                .RespondsWithStatus(HttpStatusCode.OK);
+
+            // Act
+            var request = new HttpRequestMessage(HttpMethod.Get, "https://api.example.com/users");
+            request.Headers.UserAgent.ParseAdd("Mozilla/5.0 Foo/1.0");
+            var response = await mock.GetClient().SendAsync(request);
+
+            // Assert
+            response.Should().Be200Ok();
+        }
+
+        [Fact]
+        public async Task Requires_a_header_to_be_absent_when_it_was_suppressed_with_a_trailing_colon()
+        {
+            // Arrange
+            var mock = new HttpMock();
+            mock.ImportFromCurl("curl https://api.example.com/users -H 'Accept:'")
+                .RespondsWithStatus(HttpStatusCode.OK);
+
+            // Act
+            var response = await mock.GetClient().GetAsync("https://api.example.com/users");
+
+            // Assert
+            response.Should().Be200Ok();
+        }
+
+        [Fact]
+        public async Task A_request_with_the_suppressed_header_present_is_not_matched()
+        {
+            // Arrange
+            var mock = new HttpMock();
+            mock.ImportFromCurl("curl https://api.example.com/users -H 'Accept:'")
+                .RespondsWithStatus(HttpStatusCode.OK);
+
+            // Act
+            var request = new HttpRequestMessage(HttpMethod.Get, "https://api.example.com/users");
+            request.Headers.Add("Accept", "application/json");
+            var act = () => mock.GetClient().SendAsync(request);
+
+            // Assert
+            await act.Should().ThrowAsync<UnexpectedRequestException>();
+        }
+
+        [Fact]
+        public async Task Requires_an_explicitly_empty_header_value_when_using_the_trailing_semicolon_syntax()
+        {
+            // Arrange
+            var mock = new HttpMock();
+            mock.ImportFromCurl("curl https://api.example.com/users -H 'X-Empty;'")
+                .RespondsWithStatus(HttpStatusCode.OK);
+
+            // Act
+            var request = new HttpRequestMessage(HttpMethod.Get, "https://api.example.com/users");
+            request.Headers.Add("X-Empty", string.Empty);
+            var response = await mock.GetClient().SendAsync(request);
+
+            // Assert
+            response.Should().Be200Ok();
+        }
     }
 
     public class Bodies
@@ -261,6 +372,35 @@ public class CurlImportSpecs
             // Assert
             await act.Should().ThrowAsync<UnexpectedRequestException>();
         }
+
+        [Fact]
+        public async Task Encodes_a_data_urlencode_value_the_way_curl_sends_it()
+        {
+            // Arrange
+            var mock = new HttpMock();
+            mock.ImportFromCurl("curl -X POST https://api.example.com/users --data-urlencode 'name=John Doe'")
+                .RespondsWithStatus(HttpStatusCode.Created);
+
+            // Act
+            var content = new StringContent("name=John+Doe");
+            var response = await mock.GetClient().PostAsync("https://api.example.com/users", content);
+
+            // Assert
+            response.StatusCode.Should().Be(HttpStatusCode.Created);
+        }
+
+        [Fact]
+        public void Rejects_a_data_urlencode_file_reference()
+        {
+            // Arrange
+            var mock = new HttpMock();
+
+            // Act
+            var act = () => mock.ImportFromCurl("curl -X POST https://api.example.com/users --data-urlencode '@file.txt'");
+
+            // Assert
+            act.Should().Throw<ArgumentException>().WithMessage("*file reference*");
+        }
     }
 
     public class ShellSyntax
@@ -300,6 +440,23 @@ public class CurlImportSpecs
 
             // Assert
             response.Should().Be200Ok();
+        }
+
+        [Fact]
+        public async Task Supports_a_backslash_escaped_apostrophe_outside_quotes()
+        {
+            // Arrange
+            var mock = new HttpMock();
+            mock.ImportFromCurl(
+                    "curl -X POST https://api.example.com/users -d 'name=It'\\''s a test'")
+                .RespondsWithStatus(HttpStatusCode.Created);
+
+            // Act
+            var content = new StringContent("name=It's a test");
+            var response = await mock.GetClient().PostAsync("https://api.example.com/users", content);
+
+            // Assert
+            response.StatusCode.Should().Be(HttpStatusCode.Created);
         }
     }
 

--- a/Mockly/CurlImport.cs
+++ b/Mockly/CurlImport.cs
@@ -1,0 +1,411 @@
+using System.Text;
+
+namespace Mockly;
+
+/// <summary>
+/// Represents the relevant parts of a parsed <c>curl</c> command.
+/// </summary>
+internal sealed class CurlRequest
+{
+    public string? Method { get; set; }
+
+    public string? Url { get; set; }
+
+    public IList<KeyValuePair<string, string>> Headers { get; } = new List<KeyValuePair<string, string>>();
+
+    public string? Body { get; set; }
+}
+
+/// <summary>
+/// Splits a <c>curl</c> command line into individual tokens, honoring single quotes, double quotes
+/// and shell line-continuation characters (<c>\</c>, <c>^</c> and <c>`</c>).
+/// </summary>
+internal sealed class CurlTokenizer
+{
+    private readonly string text;
+    private readonly List<string> tokens = new();
+    private readonly StringBuilder current = new();
+    private bool tokenStarted;
+    private int position;
+
+    public CurlTokenizer(string text)
+    {
+        this.text = text;
+    }
+
+    public IReadOnlyList<string> Tokenize()
+    {
+        while (position < text.Length)
+        {
+            char c = text[position];
+
+            if (c == '\'')
+            {
+                ReadSingleQuoted();
+            }
+            else if (c == '"')
+            {
+                ReadDoubleQuoted();
+            }
+            else if (c is ' ' or '\t' or '\r' or '\n')
+            {
+                FlushToken();
+                position++;
+            }
+            else if (IsLineContinuation(c))
+            {
+                position = SkipLineBreak(position + 1);
+            }
+            else
+            {
+                current.Append(c);
+                tokenStarted = true;
+                position++;
+            }
+        }
+
+        FlushToken();
+        return tokens;
+    }
+
+    private bool IsLineContinuation(char c)
+    {
+        return c is '\\' or '^' or '`' &&
+            position + 1 < text.Length &&
+            (text[position + 1] == '\n' || text[position + 1] == '\r');
+    }
+
+    private int SkipLineBreak(int index)
+    {
+        if (index < text.Length && text[index] == '\r' && index + 1 < text.Length && text[index + 1] == '\n')
+        {
+            return index + 2;
+        }
+
+        return index + 1;
+    }
+
+    private void FlushToken()
+    {
+        if (tokenStarted)
+        {
+            tokens.Add(current.ToString());
+            current.Clear();
+            tokenStarted = false;
+        }
+    }
+
+    private void ReadSingleQuoted()
+    {
+        tokenStarted = true;
+        position++;
+
+        while (position < text.Length)
+        {
+            char c = text[position];
+            if (c == '\'')
+            {
+                position++;
+                return;
+            }
+
+            current.Append(c);
+            position++;
+        }
+
+        throw new ArgumentException("The cURL command contains an unterminated single quote.");
+    }
+
+    private void ReadDoubleQuoted()
+    {
+        tokenStarted = true;
+        position++;
+
+        while (position < text.Length)
+        {
+            char c = text[position];
+            if (c == '"')
+            {
+                position++;
+                return;
+            }
+
+            if (c == '\\' && TryAppendDoubleQuoteEscape())
+            {
+                continue;
+            }
+
+            current.Append(c);
+            position++;
+        }
+
+        throw new ArgumentException("The cURL command contains an unterminated double quote.");
+    }
+
+    private bool TryAppendDoubleQuoteEscape()
+    {
+        if (position + 1 >= text.Length)
+        {
+            return false;
+        }
+
+        char next = text[position + 1];
+        if (next is '\n' or '\r')
+        {
+            position = SkipLineBreak(position + 1);
+            return true;
+        }
+
+        if (next is '"' or '\\' or '$' or '`')
+        {
+            current.Append(next);
+            position += 2;
+            return true;
+        }
+
+        return false;
+    }
+}
+
+/// <summary>
+/// Parses a tokenized <c>curl</c> command into a <see cref="CurlRequest"/>.
+/// </summary>
+internal sealed class CurlCommandParser
+{
+    private static readonly HashSet<string> ValueTakingOptions = new(StringComparer.Ordinal)
+    {
+        "-o", "--output", "-u", "--user", "-U", "--proxy-user", "-x", "--proxy", "-T", "--upload-file",
+        "--connect-timeout", "-m", "--max-time", "--retry", "--retry-delay", "--retry-max-time",
+        "--resolve", "--cacert", "--capath", "--cert", "-E", "--key", "--limit-rate", "--max-redirs",
+        "-C", "--continue-at", "-w", "--write-out", "--oauth2-bearer", "-F", "--form", "--cert-type",
+        "--key-type", "--proxy-header", "--interface", "--dns-servers", "--noproxy", "--range", "-r"
+    };
+
+    private readonly IReadOnlyList<string> tokens;
+    private readonly CurlRequest request = new();
+    private readonly List<string> dataParts = new();
+    private int position;
+
+    private CurlCommandParser(IReadOnlyList<string> tokens)
+    {
+        this.tokens = tokens;
+    }
+
+    public static CurlRequest Parse(string curlCommand)
+    {
+        if (string.IsNullOrWhiteSpace(curlCommand))
+        {
+            throw new ArgumentException("The cURL command must not be empty.", nameof(curlCommand));
+        }
+
+        IReadOnlyList<string> parsedTokens = new CurlTokenizer(curlCommand).Tokenize();
+        return new CurlCommandParser(parsedTokens).ParseTokens(curlCommand);
+    }
+
+    private CurlRequest ParseTokens(string curlCommand)
+    {
+        SkipExecutableName();
+
+        while (position < tokens.Count)
+        {
+            string token = tokens[position];
+            if (IsOption(token))
+            {
+                ParseOption(token);
+            }
+            else
+            {
+                request.Url ??= token;
+                position++;
+            }
+        }
+
+        return Build(curlCommand);
+    }
+
+    private void SkipExecutableName()
+    {
+        if (tokens.Count > 0 && string.Equals(tokens[0], "curl", StringComparison.OrdinalIgnoreCase))
+        {
+            position = 1;
+        }
+    }
+
+    private static bool IsOption(string token)
+    {
+        return token.Length > 1 && token[0] == '-';
+    }
+
+    private static int IndexOfChar(string text, char value)
+    {
+        for (int i = 0; i < text.Length; i++)
+        {
+            if (text[i] == value)
+            {
+                return i;
+            }
+        }
+
+        return -1;
+    }
+
+    private void ParseOption(string token)
+    {
+        string name;
+        string? inlineValue = null;
+
+        if (token.StartsWith("--", StringComparison.Ordinal))
+        {
+            int separator = IndexOfChar(token, '=');
+            if (separator >= 0)
+            {
+                name = token.Substring(0, separator);
+                inlineValue = token.Substring(separator + 1);
+            }
+            else
+            {
+                name = token;
+            }
+        }
+        else
+        {
+            name = token.Substring(0, 2);
+            if (token.Length > 2)
+            {
+                inlineValue = token.Substring(2);
+            }
+        }
+
+        position++;
+        DispatchOption(name, inlineValue);
+    }
+
+    private void DispatchOption(string name, string? inlineValue)
+    {
+        switch (name)
+        {
+            case "-X":
+            case "--request":
+            {
+                request.Method = ConsumeValue(name, inlineValue);
+                break;
+            }
+
+            case "-H":
+            case "--header":
+            {
+                AddHeader(ConsumeValue(name, inlineValue));
+                break;
+            }
+
+            case "-d":
+            case "--data":
+            case "--data-raw":
+            case "--data-ascii":
+            case "--data-binary":
+            case "--data-urlencode":
+            {
+                dataParts.Add(ConsumeValue(name, inlineValue));
+                break;
+            }
+
+            case "--url":
+            {
+                request.Url = ConsumeValue(name, inlineValue);
+                break;
+            }
+
+            case "-A":
+            case "--user-agent":
+            {
+                AddHeaderValue("User-Agent", ConsumeValue(name, inlineValue));
+                break;
+            }
+
+            case "-e":
+            case "--referer":
+            {
+                AddHeaderValue("Referer", ConsumeValue(name, inlineValue));
+                break;
+            }
+
+            case "-b":
+            case "--cookie":
+            {
+                AddHeaderValue("Cookie", ConsumeValue(name, inlineValue));
+                break;
+            }
+
+            default:
+            {
+                SkipUnknownOption(name, inlineValue);
+                break;
+            }
+        }
+    }
+
+    private void SkipUnknownOption(string name, string? inlineValue)
+    {
+        // Unknown boolean flags (such as --compressed) are ignored. Options known to take a value are
+        // consumed so their value is not mistaken for the URL (for example "-u user:pass").
+        if (inlineValue is null && ValueTakingOptions.Contains(name))
+        {
+            ConsumeValue(name, inlineValue);
+        }
+    }
+
+    private string ConsumeValue(string optionName, string? inlineValue)
+    {
+        if (inlineValue is not null)
+        {
+            return inlineValue;
+        }
+
+        if (position >= tokens.Count)
+        {
+            throw new ArgumentException($"The cURL option '{optionName}' is missing a value.");
+        }
+
+        string value = tokens[position];
+        position++;
+        return value;
+    }
+
+    private void AddHeader(string header)
+    {
+        int separator = IndexOfChar(header, ':');
+        if (separator < 0)
+        {
+            throw new ArgumentException($"The header '{header}' is not in the expected 'Name: Value' format.");
+        }
+
+        string name = header.Substring(0, separator).Trim();
+        string value = header.Substring(separator + 1).Trim();
+        if (name.Length == 0)
+        {
+            throw new ArgumentException($"The header '{header}' does not specify a name.");
+        }
+
+        AddHeaderValue(name, value);
+    }
+
+    private void AddHeaderValue(string name, string value)
+    {
+        request.Headers.Add(new KeyValuePair<string, string>(name, value));
+    }
+
+    private CurlRequest Build(string curlCommand)
+    {
+        if (dataParts.Count > 0)
+        {
+            request.Body = string.Join("&", dataParts);
+        }
+
+        if (string.IsNullOrEmpty(request.Url))
+        {
+            throw new ArgumentException("The cURL command does not contain a URL.", nameof(curlCommand));
+        }
+
+        return request;
+    }
+}

--- a/Mockly/CurlImport.cs
+++ b/Mockly/CurlImport.cs
@@ -404,12 +404,12 @@ internal sealed class CurlCommandParser
                     "The cURL option '--data-urlencode' with a file reference (@filename or name@filename) is not supported.");
             }
 
-            return WebUtility.UrlEncode(raw) ?? string.Empty;
+            return WebUtility.UrlEncode(raw);
         }
 
         string name = raw.Substring(0, separator);
         string content = raw.Substring(separator + 1);
-        string encodedContent = WebUtility.UrlEncode(content) ?? string.Empty;
+        string encodedContent = WebUtility.UrlEncode(content);
 
         return name.Length == 0 ? encodedContent : $"{name}={encodedContent}";
     }

--- a/Mockly/CurlImport.cs
+++ b/Mockly/CurlImport.cs
@@ -1,3 +1,4 @@
+using System.Net;
 using System.Text;
 
 namespace Mockly;
@@ -11,27 +12,26 @@ internal sealed class CurlRequest
 
     public string? Url { get; set; }
 
-    public IList<KeyValuePair<string, string>> Headers { get; } = new List<KeyValuePair<string, string>>();
+    /// <summary>
+    /// Headers to apply. A <c>null</c> value means the header must be excluded (curl's <c>Name:</c> syntax),
+    /// while a non-null value (including an empty string, curl's <c>Name;</c> syntax) means the header must
+    /// be present with that value.
+    /// </summary>
+    public IList<KeyValuePair<string, string?>> Headers { get; } = new List<KeyValuePair<string, string?>>();
 
     public string? Body { get; set; }
 }
 
 /// <summary>
-/// Splits a <c>curl</c> command line into individual tokens, honoring single quotes, double quotes
-/// and shell line-continuation characters (<c>\</c>, <c>^</c> and <c>`</c>).
+/// Splits a <c>curl</c> command line into individual tokens, honoring single quotes, double quotes,
+/// unquoted backslash escapes and shell line-continuation characters (<c>\</c>, <c>^</c> and <c>`</c>).
 /// </summary>
-internal sealed class CurlTokenizer
+internal sealed class CurlTokenizer(string text)
 {
-    private readonly string text;
     private readonly List<string> tokens = new();
     private readonly StringBuilder current = new();
     private bool tokenStarted;
     private int position;
-
-    public CurlTokenizer(string text)
-    {
-        this.text = text;
-    }
 
     public IReadOnlyList<string> Tokenize()
     {
@@ -56,6 +56,10 @@ internal sealed class CurlTokenizer
             {
                 position = SkipLineBreak(position + 1);
             }
+            else if (c == '\\')
+            {
+                AppendUnquotedEscape();
+            }
             else
             {
                 current.Append(c);
@@ -66,6 +70,27 @@ internal sealed class CurlTokenizer
 
         FlushToken();
         return tokens;
+    }
+
+    /// <summary>
+    /// Handles a backslash outside quotes. Per POSIX shell rules, it escapes the following character
+    /// (removing any special meaning it would otherwise have), which is how tools such as browser
+    /// DevTools embed an apostrophe in a copied <c>curl</c> command (e.g. <c>'\''</c>).
+    /// </summary>
+    private void AppendUnquotedEscape()
+    {
+        tokenStarted = true;
+        position++;
+
+        if (position < text.Length)
+        {
+            current.Append(text[position]);
+            position++;
+        }
+        else
+        {
+            current.Append('\\');
+        }
     }
 
     private bool IsLineContinuation(char c)
@@ -199,10 +224,10 @@ internal sealed class CurlCommandParser
         }
 
         IReadOnlyList<string> parsedTokens = new CurlTokenizer(curlCommand).Tokenize();
-        return new CurlCommandParser(parsedTokens).ParseTokens(curlCommand);
+        return new CurlCommandParser(parsedTokens).ParseTokens();
     }
 
-    private CurlRequest ParseTokens(string curlCommand)
+    private CurlRequest ParseTokens()
     {
         SkipExecutableName();
 
@@ -220,7 +245,7 @@ internal sealed class CurlCommandParser
             }
         }
 
-        return Build(curlCommand);
+        return Build();
     }
 
     private void SkipExecutableName()
@@ -236,19 +261,6 @@ internal sealed class CurlCommandParser
         return token.Length > 1 && token[0] == '-';
     }
 
-    private static int IndexOfChar(string text, char value)
-    {
-        for (int i = 0; i < text.Length; i++)
-        {
-            if (text[i] == value)
-            {
-                return i;
-            }
-        }
-
-        return -1;
-    }
-
     private void ParseOption(string token)
     {
         string name;
@@ -256,7 +268,7 @@ internal sealed class CurlCommandParser
 
         if (token.StartsWith("--", StringComparison.Ordinal))
         {
-            int separator = IndexOfChar(token, '=');
+            int separator = token.IndexOf("=", StringComparison.Ordinal);
             if (separator >= 0)
             {
                 name = token.Substring(0, separator);
@@ -303,9 +315,14 @@ internal sealed class CurlCommandParser
             case "--data-raw":
             case "--data-ascii":
             case "--data-binary":
-            case "--data-urlencode":
             {
                 dataParts.Add(ConsumeValue(name, inlineValue));
+                break;
+            }
+
+            case "--data-urlencode":
+            {
+                dataParts.Add(EncodeDataUrlEncodeValue(ConsumeValue(name, inlineValue)));
                 break;
             }
 
@@ -371,11 +388,53 @@ internal sealed class CurlCommandParser
         return value;
     }
 
-    private void AddHeader(string header)
+    /// <summary>
+    /// Applies the encoding <c>--data-urlencode</c> performs before curl sends the request, supporting the
+    /// <c>content</c>, <c>=content</c> and <c>name=content</c> forms. The <c>@filename</c> and
+    /// <c>name@filename</c> forms read from a file and are not supported.
+    /// </summary>
+    private static string EncodeDataUrlEncodeValue(string raw)
     {
-        int separator = IndexOfChar(header, ':');
+        int separator = raw.IndexOf("=", StringComparison.Ordinal);
         if (separator < 0)
         {
+            if (HasFileReference(raw))
+            {
+                throw new ArgumentException(
+                    "The cURL option '--data-urlencode' with a file reference (@filename or name@filename) is not supported.");
+            }
+
+            return WebUtility.UrlEncode(raw) ?? string.Empty;
+        }
+
+        string name = raw.Substring(0, separator);
+        string content = raw.Substring(separator + 1);
+        string encodedContent = WebUtility.UrlEncode(content) ?? string.Empty;
+
+        return name.Length == 0 ? encodedContent : $"{name}={encodedContent}";
+    }
+
+    private static bool HasFileReference(string raw)
+    {
+#if NET8_0_OR_GREATER
+        return raw.Contains('@', StringComparison.Ordinal);
+#else
+        return raw.Contains("@", StringComparison.Ordinal);
+#endif
+    }
+
+    private void AddHeader(string header)
+    {
+        int separator = header.IndexOf(":", StringComparison.Ordinal);
+        if (separator < 0)
+        {
+            // curl's "Name;" syntax explicitly sends the header with an empty value.
+            if (header.EndsWith(";", StringComparison.Ordinal) && header.Length > 1)
+            {
+                AddHeaderValue(header.Substring(0, header.Length - 1).Trim(), string.Empty);
+                return;
+            }
+
             throw new ArgumentException($"The header '{header}' is not in the expected 'Name: Value' format.");
         }
 
@@ -386,15 +445,22 @@ internal sealed class CurlCommandParser
             throw new ArgumentException($"The header '{header}' does not specify a name.");
         }
 
+        if (value.Length == 0)
+        {
+            // curl's "Name:" syntax suppresses that header rather than sending it with an empty value.
+            request.Headers.Add(new KeyValuePair<string, string?>(name, null));
+            return;
+        }
+
         AddHeaderValue(name, value);
     }
 
     private void AddHeaderValue(string name, string value)
     {
-        request.Headers.Add(new KeyValuePair<string, string>(name, value));
+        request.Headers.Add(new KeyValuePair<string, string?>(name, value));
     }
 
-    private CurlRequest Build(string curlCommand)
+    private CurlRequest Build()
     {
         if (dataParts.Count > 0)
         {
@@ -403,7 +469,7 @@ internal sealed class CurlCommandParser
 
         if (string.IsNullOrEmpty(request.Url))
         {
-            throw new ArgumentException("The cURL command does not contain a URL.", nameof(curlCommand));
+            throw new ArgumentException("The cURL command does not contain a URL.");
         }
 
         return request;

--- a/Mockly/HttpMock.cs
+++ b/Mockly/HttpMock.cs
@@ -1,6 +1,7 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Net;
 using System.Text;
+using System.Text.Json;
 using Mockly.Common;
 #if NET472_OR_GREATER
 using System.Net.Http;
@@ -176,6 +177,51 @@ public class HttpMock
     {
         var builder = ForDelete();
         builder = ApplyUrlPattern(builder, urlPattern);
+        previousBuilder = builder;
+        return builder;
+    }
+
+    /// <summary>
+    /// Builds a request mock from a <c>curl</c> command string, such as the output of a browser's
+    /// "Copy as cURL" command.
+    /// </summary>
+    /// <remarks>
+    /// The HTTP method (<c>-X</c>), URL, headers (<c>-H</c>) and body (<c>-d</c>, <c>--data</c>, <c>--data-raw</c>, ...)
+    /// are translated into the equivalent request matching configuration. When no method is specified, <c>POST</c> is
+    /// assumed if a body is present and <c>GET</c> otherwise. Attach a response (for example
+    /// <see cref="RequestMockBuilder.RespondsWithStatus"/>) to the returned builder to complete the mock.
+    /// </remarks>
+    /// <param name="curlCommand">The <c>curl</c> command to import.</param>
+    /// <returns>A <see cref="RequestMockBuilder"/> configured to match the imported request.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="curlCommand"/> is <c>null</c>.</exception>
+    /// <exception cref="ArgumentException"><paramref name="curlCommand"/> is empty or cannot be parsed.</exception>
+    public RequestMockBuilder ImportFromCurl(string curlCommand)
+    {
+        if (curlCommand is null)
+        {
+            throw new ArgumentNullException(nameof(curlCommand));
+        }
+
+        CurlRequest parsed = CurlCommandParser.Parse(curlCommand);
+
+        var builder = new RequestMockBuilder(this, ResolveMethod(parsed));
+        builder = ApplyUrlPattern(builder, parsed.Url!);
+
+        foreach (KeyValuePair<string, string> header in parsed.Headers)
+        {
+            if (IsUnsupportedContentHeader(header.Key))
+            {
+                continue;
+            }
+
+            builder = ApplyHeader(builder, header.Key, header.Value);
+        }
+
+        if (parsed.Body is not null)
+        {
+            builder = ApplyBody(builder, parsed.Body, HasJsonContentType(parsed));
+        }
+
         previousBuilder = builder;
         return builder;
     }
@@ -521,6 +567,95 @@ public class HttpMock
         }
 
         return builder;
+    }
+
+    private static HttpMethod ResolveMethod(CurlRequest parsed)
+    {
+        if (!string.IsNullOrEmpty(parsed.Method))
+        {
+            return new HttpMethod(parsed.Method!.ToUpperInvariant());
+        }
+
+        return parsed.Body is not null ? HttpMethod.Post : HttpMethod.Get;
+    }
+
+    private static RequestMockBuilder ApplyHeader(RequestMockBuilder builder, string name, string value)
+    {
+        return builder.With(request => HeaderMatches(request, name, value), $"header '{name}: {value}'");
+    }
+
+    private static RequestMockBuilder ApplyBody(RequestMockBuilder builder, string body, bool jsonContentType)
+    {
+        if (IsJsonBody(body, jsonContentType))
+        {
+            return builder.WithBodyMatchingJson(body);
+        }
+
+        return builder.With(
+            request => string.Equals(request.Body, body, StringComparison.Ordinal),
+            $"body equals \"{body}\"");
+    }
+
+    private static bool IsUnsupportedContentHeader(string name)
+    {
+        return name.StartsWith("Content-", StringComparison.OrdinalIgnoreCase) &&
+            !string.Equals(name, "Content-Type", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static bool HasJsonContentType(CurlRequest parsed)
+    {
+        foreach (KeyValuePair<string, string> header in parsed.Headers)
+        {
+            if (string.Equals(header.Key, "Content-Type", StringComparison.OrdinalIgnoreCase) &&
+                header.Value.Contains("json", StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool HeaderMatches(RequestInfo request, string name, string value)
+    {
+        if (string.Equals(name, "Content-Type", StringComparison.OrdinalIgnoreCase))
+        {
+            string expected = value.Split(';')[0].Trim();
+            return request.ContentType is { } actual &&
+                string.Equals(actual, expected, StringComparison.OrdinalIgnoreCase);
+        }
+
+        if (request.Headers.TryGetValues(name, out IEnumerable<string>? values))
+        {
+            return values.Any(v => string.Equals(v, value, StringComparison.Ordinal)) ||
+                string.Equals(string.Join(", ", values), value, StringComparison.Ordinal);
+        }
+
+        return false;
+    }
+
+    private static bool IsJsonBody(string body, bool jsonContentType)
+    {
+        string trimmed = body.TrimStart();
+        if (trimmed.Length == 0)
+        {
+            return false;
+        }
+
+        if (!jsonContentType && trimmed[0] != '{' && trimmed[0] != '[')
+        {
+            return false;
+        }
+
+        try
+        {
+            using var document = JsonDocument.Parse(body);
+            return true;
+        }
+        catch (JsonException)
+        {
+            return false;
+        }
     }
 
 #pragma warning restore CA1054

--- a/Mockly/HttpMock.cs
+++ b/Mockly/HttpMock.cs
@@ -6,6 +6,8 @@ using System.Text.Json;
 using Mockly.Common;
 #if NET472_OR_GREATER
 using System.Net.Http;
+#else
+using System.Net.Http.Headers;
 #endif
 
 #pragma warning disable CA1054
@@ -221,16 +223,18 @@ public class HttpMock
         CurlRequest parsed = CurlCommandParser.Parse(curlCommand);
 
         var builder = new RequestMockBuilder(this, ResolveMethod(parsed));
-        builder = ApplyUrlPattern(builder, parsed.Url!);
+        builder = ApplyCurlUrl(builder, parsed.Url!);
 
-        foreach (KeyValuePair<string, string> header in parsed.Headers)
+        foreach (KeyValuePair<string, string?> header in parsed.Headers)
         {
             if (IsUnsupportedContentHeader(header.Key))
             {
                 continue;
             }
 
-            builder = ApplyHeader(builder, header.Key, header.Value);
+            builder = header.Value is null
+                ? ApplyHeaderExclusion(builder, header.Key)
+                : ApplyHeader(builder, header.Key, header.Value);
         }
 
         if (parsed.Body is not null)
@@ -523,6 +527,51 @@ public class HttpMock
     }
 
     /// <summary>
+    /// Configures scheme, host, path and query for a curl-imported URL using literal (non-wildcard) semantics,
+    /// since the URL comes from an actual request rather than being an intentional Mockly matching pattern.
+    /// </summary>
+    private static RequestMockBuilder ApplyCurlUrl(RequestMockBuilder builder, string rawUrl)
+    {
+        Uri uri = ParseCurlUrl(rawUrl);
+
+        builder = string.Equals(uri.Scheme, "https", StringComparison.OrdinalIgnoreCase)
+            ? builder.ForHttps()
+            : builder.ForHttp();
+
+        builder = builder.ForHost(uri.IsDefaultPort ? uri.Host : $"{uri.Host}:{uri.Port}");
+
+        string path = uri.AbsolutePath;
+        builder = builder.With(
+            request => string.Equals(request.Uri?.AbsolutePath, path, StringComparison.Ordinal),
+            $"path equals '{path}'");
+
+        string query = WebUtility.UrlDecode(uri.Query);
+        builder = builder.With(
+            request => string.Equals(WebUtility.UrlDecode(request.Uri?.Query ?? string.Empty), query, StringComparison.Ordinal),
+            query.Length > 0 ? $"query equals '{query}'" : "no query string");
+
+        return builder;
+    }
+
+    /// <summary>
+    /// Parses a curl URL into an absolute <see cref="Uri"/>, defaulting to the <c>http</c> scheme when none is
+    /// specified, matching curl's own default (unlike Mockly's builder, which defaults to <c>https</c>).
+    /// </summary>
+    private static Uri ParseCurlUrl(string rawUrl)
+    {
+        string trimmed = rawUrl.Trim();
+
+        if (Uri.TryCreate(trimmed, UriKind.Absolute, out Uri? uri) &&
+            (string.Equals(uri.Scheme, "http", StringComparison.OrdinalIgnoreCase) ||
+                string.Equals(uri.Scheme, "https", StringComparison.OrdinalIgnoreCase)))
+        {
+            return uri;
+        }
+
+        return new Uri("http://" + trimmed, UriKind.Absolute);
+    }
+
+    /// <summary>
     /// Parses a full URL pattern (e.g. <c>"https://api.example.com/v1/users?active=*"</c>) and
     /// applies the scheme, host, path, and query segments to <paramref name="builder"/>.
     /// Wildcards (<c>*</c>) are supported in every segment.
@@ -637,6 +686,20 @@ public class HttpMock
         return builder.With(request => HeaderMatches(request, name, value), $"header '{name}: {value}'");
     }
 
+    /// <summary>
+    /// Configures the mock to require the given header to be absent, mirroring curl's <c>-H 'Name:'</c> syntax
+    /// which suppresses a header rather than sending it with an empty value.
+    /// </summary>
+    private static RequestMockBuilder ApplyHeaderExclusion(RequestMockBuilder builder, string name)
+    {
+        if (string.Equals(name, "Content-Type", StringComparison.OrdinalIgnoreCase))
+        {
+            return builder.With(request => request.ContentType is null, $"header '{name}' is absent");
+        }
+
+        return builder.With(request => !request.Headers.Contains(name), $"header '{name}' is absent");
+    }
+
     private static RequestMockBuilder ApplyBody(RequestMockBuilder builder, string body, bool jsonContentType)
     {
         if (IsJsonBody(body, jsonContentType))
@@ -657,10 +720,10 @@ public class HttpMock
 
     private static bool HasJsonContentType(CurlRequest parsed)
     {
-        foreach (KeyValuePair<string, string> header in parsed.Headers)
+        foreach (KeyValuePair<string, string?> header in parsed.Headers)
         {
             if (string.Equals(header.Key, "Content-Type", StringComparison.OrdinalIgnoreCase) &&
-                header.Value.Contains("json", StringComparison.OrdinalIgnoreCase))
+                header.Value is not null && header.Value.Contains("json", StringComparison.OrdinalIgnoreCase))
             {
                 return true;
             }
@@ -678,13 +741,31 @@ public class HttpMock
                 string.Equals(actual, expected, StringComparison.OrdinalIgnoreCase);
         }
 
-        if (request.Headers.TryGetValues(name, out IEnumerable<string>? values))
+#if NET8_0_OR_GREATER
+        // Use the raw, non-validated header representation so headers whose values are split into multiple
+        // tokens by .NET's typed parsing (such as User-Agent, which is space- rather than comma-separated)
+        // are compared using their original textual form instead of being rejoined with a comma.
+        if (!request.Headers.NonValidated.TryGetValues(name, out HeaderStringValues values))
         {
-            return values.Any(v => string.Equals(v, value, StringComparison.Ordinal)) ||
-                string.Equals(string.Join(", ", values), value, StringComparison.Ordinal);
+            return false;
         }
 
-        return false;
+        return values.Any(v => string.Equals(v, value, StringComparison.Ordinal)) ||
+            string.Equals(values.ToString(), value, StringComparison.Ordinal);
+#else
+        // net472 lacks HttpHeaders.NonValidated, so the original separator can't be recovered; try both the
+        // comma (the list syntax most headers use) and the space (used by product-token headers like
+        // User-Agent) to reconstruct the value .NET split into multiple tokens.
+        if (!request.Headers.TryGetValues(name, out IEnumerable<string>? values))
+        {
+            return false;
+        }
+
+        List<string> materializedValues = values.ToList();
+        return materializedValues.Any(v => string.Equals(v, value, StringComparison.Ordinal)) ||
+            string.Equals(string.Join(", ", materializedValues), value, StringComparison.Ordinal) ||
+            string.Equals(string.Join(" ", materializedValues), value, StringComparison.Ordinal);
+#endif
     }
 
     private static bool IsJsonBody(string body, bool jsonContentType)

--- a/Mockly/HttpMock.cs
+++ b/Mockly/HttpMock.cs
@@ -2,6 +2,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Net;
 using System.Runtime.ExceptionServices;
 using System.Text;
+using System.Text.Json;
 using Mockly.Common;
 #if NET472_OR_GREATER
 using System.Net.Http;
@@ -191,6 +192,51 @@ public class HttpMock
                 Method = method
             }
             : new RequestMockBuilder(this, method);
+
+        previousBuilder = builder;
+        return builder;
+    }
+
+    /// <summary>
+    /// Builds a request mock from a <c>curl</c> command string, such as the output of a browser's
+    /// "Copy as cURL" command.
+    /// </summary>
+    /// <remarks>
+    /// The HTTP method (<c>-X</c>), URL, headers (<c>-H</c>) and body (<c>-d</c>, <c>--data</c>, <c>--data-raw</c>, ...)
+    /// are translated into the equivalent request matching configuration. When no method is specified, <c>POST</c> is
+    /// assumed if a body is present and <c>GET</c> otherwise. Attach a response (for example
+    /// <see cref="RequestMockBuilder.RespondsWithStatus"/>) to the returned builder to complete the mock.
+    /// </remarks>
+    /// <param name="curlCommand">The <c>curl</c> command to import.</param>
+    /// <returns>A <see cref="RequestMockBuilder"/> configured to match the imported request.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="curlCommand"/> is <c>null</c>.</exception>
+    /// <exception cref="ArgumentException"><paramref name="curlCommand"/> is empty or cannot be parsed.</exception>
+    public RequestMockBuilder ImportFromCurl(string curlCommand)
+    {
+        if (curlCommand is null)
+        {
+            throw new ArgumentNullException(nameof(curlCommand));
+        }
+
+        CurlRequest parsed = CurlCommandParser.Parse(curlCommand);
+
+        var builder = new RequestMockBuilder(this, ResolveMethod(parsed));
+        builder = ApplyUrlPattern(builder, parsed.Url!);
+
+        foreach (KeyValuePair<string, string> header in parsed.Headers)
+        {
+            if (IsUnsupportedContentHeader(header.Key))
+            {
+                continue;
+            }
+
+            builder = ApplyHeader(builder, header.Key, header.Value);
+        }
+
+        if (parsed.Body is not null)
+        {
+            builder = ApplyBody(builder, parsed.Body, HasJsonContentType(parsed));
+        }
 
         previousBuilder = builder;
         return builder;
@@ -574,6 +620,95 @@ public class HttpMock
         }
 
         return builder;
+    }
+
+    private static HttpMethod ResolveMethod(CurlRequest parsed)
+    {
+        if (!string.IsNullOrEmpty(parsed.Method))
+        {
+            return new HttpMethod(parsed.Method!.ToUpperInvariant());
+        }
+
+        return parsed.Body is not null ? HttpMethod.Post : HttpMethod.Get;
+    }
+
+    private static RequestMockBuilder ApplyHeader(RequestMockBuilder builder, string name, string value)
+    {
+        return builder.With(request => HeaderMatches(request, name, value), $"header '{name}: {value}'");
+    }
+
+    private static RequestMockBuilder ApplyBody(RequestMockBuilder builder, string body, bool jsonContentType)
+    {
+        if (IsJsonBody(body, jsonContentType))
+        {
+            return builder.WithBodyMatchingJson(body);
+        }
+
+        return builder.With(
+            request => string.Equals(request.Body, body, StringComparison.Ordinal),
+            $"body equals \"{body}\"");
+    }
+
+    private static bool IsUnsupportedContentHeader(string name)
+    {
+        return name.StartsWith("Content-", StringComparison.OrdinalIgnoreCase) &&
+            !string.Equals(name, "Content-Type", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static bool HasJsonContentType(CurlRequest parsed)
+    {
+        foreach (KeyValuePair<string, string> header in parsed.Headers)
+        {
+            if (string.Equals(header.Key, "Content-Type", StringComparison.OrdinalIgnoreCase) &&
+                header.Value.Contains("json", StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool HeaderMatches(RequestInfo request, string name, string value)
+    {
+        if (string.Equals(name, "Content-Type", StringComparison.OrdinalIgnoreCase))
+        {
+            string expected = value.Split(';')[0].Trim();
+            return request.ContentType is { } actual &&
+                string.Equals(actual, expected, StringComparison.OrdinalIgnoreCase);
+        }
+
+        if (request.Headers.TryGetValues(name, out IEnumerable<string>? values))
+        {
+            return values.Any(v => string.Equals(v, value, StringComparison.Ordinal)) ||
+                string.Equals(string.Join(", ", values), value, StringComparison.Ordinal);
+        }
+
+        return false;
+    }
+
+    private static bool IsJsonBody(string body, bool jsonContentType)
+    {
+        string trimmed = body.TrimStart();
+        if (trimmed.Length == 0)
+        {
+            return false;
+        }
+
+        if (!jsonContentType && trimmed[0] != '{' && trimmed[0] != '[')
+        {
+            return false;
+        }
+
+        try
+        {
+            using var document = JsonDocument.Parse(body);
+            return true;
+        }
+        catch (JsonException)
+        {
+            return false;
+        }
     }
 
 #pragma warning restore CA1054

--- a/README.md
+++ b/README.md
@@ -140,6 +140,22 @@ mock.FailOnUnexpectedCalls = true; // Default behavior
 // Throws UnexpectedRequestException if an unmocked request is made
 ```
 
+### 📥 Import From cURL
+
+Bootstrap a mock from an existing `curl` command, such as the output of a browser's "Copy as cURL":
+
+```csharp
+mock.ImportFromCurl("""
+    curl -X POST https://api.example.com/users \
+      -H 'Content-Type: application/json' \
+      --data-raw '{"name":"mockly"}'
+    """)
+    .RespondsWithStatus(HttpStatusCode.Created);
+```
+
+The method (`-X`), URL, headers (`-H`) and body (`-d`/`--data`/`--data-raw`) are translated into the
+equivalent matching configuration. Importing HAR files is planned for a future release.
+
 ## Quick Start
 
 Install the package:

--- a/README.md
+++ b/README.md
@@ -213,6 +213,22 @@ mock.FailOnUnexpectedCalls = true; // Default behavior
 // Throws UnexpectedRequestException if an unmocked request is made
 ```
 
+### 📥 Import From cURL
+
+Bootstrap a mock from an existing `curl` command, such as the output of a browser's "Copy as cURL":
+
+```csharp
+mock.ImportFromCurl("""
+    curl -X POST https://api.example.com/users \
+      -H 'Content-Type: application/json' \
+      --data-raw '{"name":"mockly"}'
+    """)
+    .RespondsWithStatus(HttpStatusCode.Created);
+```
+
+The method (`-X`), URL, headers (`-H`) and body (`-d`/`--data`/`--data-raw`) are translated into the
+equivalent matching configuration. Importing HAR files is planned for a future release.
+
 ## Quick Start
 
 Install the package:


### PR DESCRIPTION
Closes #124

## Summary

Adds `HttpMock.ImportFromCurl(string curlCommand)` to bootstrap a request mock from an existing `curl` command — for example the output of a browser's "Copy as cURL" or a snippet from API docs. The parsed request is translated into the equivalent fluent matching configuration and a `RequestMockBuilder` is returned so a response can be attached:

```csharp
mock.ImportFromCurl("""
    curl -X POST https://api.example.com/users \
      -H 'Content-Type: application/json' \
      --data-raw '{"name":"mockly"}'
    """)
    .RespondsWithStatus(HttpStatusCode.Created);
```

This PR is **scoped to cURL only (Phase 1)**. HAR import is **deferred to a follow-up PR** (see the issue's Phase 2). No new runtime dependency is introduced — parsing uses only the BCL and `System.Text.Json`.

## New public API

- `Mockly.HttpMock.ImportFromCurl(string curlCommand) : RequestMockBuilder`

(API verification files under `Mockly.ApiVerificationTests/ApprovedApi` were regenerated via `AcceptApiChanges.ps1`.)

## What gets parsed

- **Method** — `-X`/`--request`. Defaults to `POST` when a body is present, otherwise `GET`.
- **URL** — the bare argument or `--url`; scheme, host, path and query are mapped onto the builder.
- **Headers** — `-H`/`--header` (plus `-A`/`--user-agent`, `-e`/`--referer`, `-b`/`--cookie`). `Content-Type` is matched against the request's content type (parameters such as `charset` ignored).
- **Body** — `-d`/`--data`/`--data-raw`/`--data-ascii`/`--data-binary`/`--data-urlencode`. JSON bodies are matched whitespace-insensitively; other bodies are matched exactly. Multiple data options are joined with `&`.

### Shell syntax handling

- Single quotes, double quotes (with `\" \\ \$ \``  escapes), and line continuations (`\`, `^`, `` ` `` followed by a newline).
- A leading `curl` token is ignored.
- Options known to take a value (e.g. `-u user:pass`, `-o`, `--connect-timeout`) are consumed so their value is not mistaken for the URL. Other unknown flags are ignored.
- Malformed input (empty command, missing URL, missing option value, unterminated quote, malformed header) throws a clear `ArgumentException` (`ArgumentNullException` for `null`).

## Tests

Added `Mockly.Specs/CurlImportSpecs.cs` (xUnit + FluentAssertions, AAA, nested classes) covering GET, query strings, explicit/lowercase/defaulted methods, single & multiple headers, JSON and form-encoded bodies, exact-body negative matching, value-taking option handling, line continuations and double quotes, plus malformed-input cases. Full suite is green on `net8.0` (111) and `net472` (110).

## Notes for reviewers

- **Header strictness:** faithful to the issue, every imported `-H` becomes a matcher. Browser "Copy as cURL" output includes volatile headers (`User-Agent`, `Accept`, `Sec-*`), so an imported mock can be stricter than a plain `HttpClient` request. Happy to soften this (e.g. only match a curated subset by default) if preferred.
- **Unsupported content headers** (e.g. `Content-Length`, `Content-Encoding`) are skipped rather than turned into matchers that could never pass.
- Semantic edge cases such as `--data @file`, `--data-urlencode` encoding, and `-G` are not specially handled yet; can be added if in scope.

🤖 Generated with [GitHub Copilot CLI](https://github.com/github/copilot-cli)