### PR TITLE
Add simulated network failures ThrowsException/TimesOut

### DIFF
--- a/Mockly.ApiVerificationTests/ApprovedApi/net472.verified.txt
+++ b/Mockly.ApiVerificationTests/ApprovedApi/net472.verified.txt
@@ -17,6 +17,7 @@ namespace Mockly
         public System.Net.Http.HttpResponseMessage Response { get; }
         public string Scheme { get; }
         public int Sequence { get; set; }
+        public System.Exception? SimulatedFailure { get; }
         public System.DateTime Timestamp { get; }
         public System.Uri? Uri { get; }
         public System.Version Version { get; }
@@ -134,6 +135,10 @@ namespace Mockly
         public Mockly.SequencedResponseBuilder RespondsWithProblemDetails(System.Net.HttpStatusCode statusCode, string? title = null, string? detail = null, string? type = null, string? instance = null, System.Collections.Generic.IDictionary<string, object?>? extensions = null) { }
         public Mockly.SequencedResponseBuilder RespondsWithStatus(System.Net.HttpStatusCode statusCode) { }
         public Mockly.SequencedResponseBuilder RespondsWithStream(System.IO.Stream stream, string contentType) { }
+        public Mockly.RequestMockResponseBuilder ThrowsException(System.Exception exception) { }
+        public Mockly.RequestMockResponseBuilder ThrowsException<TException>()
+            where TException : System.Exception, new () { }
+        public Mockly.RequestMockResponseBuilder TimesOut() { }
         public Mockly.RequestMockBuilder TreatBodyAsTextual() { }
         public Mockly.RequestMockBuilder Using(System.Text.Json.JsonSerializerOptions options) { }
         public Mockly.RequestMockBuilder With(System.Func<Mockly.RequestInfo, System.Threading.Tasks.Task<bool>> matcher, [System.Runtime.CompilerServices.CallerArgumentExpression("matcher")] string? matcherText = null) { }

--- a/Mockly.ApiVerificationTests/ApprovedApi/net8.0.verified.txt
+++ b/Mockly.ApiVerificationTests/ApprovedApi/net8.0.verified.txt
@@ -18,6 +18,7 @@ namespace Mockly
         public System.Net.Http.HttpResponseMessage Response { get; }
         public string Scheme { get; }
         public int Sequence { get; set; }
+        public System.Exception? SimulatedFailure { get; }
         public System.DateTime Timestamp { get; }
         public System.Uri? Uri { get; }
         public System.Version Version { get; }
@@ -137,6 +138,10 @@ namespace Mockly
         public Mockly.SequencedResponseBuilder RespondsWithProblemDetails(System.Net.HttpStatusCode statusCode, string? title = null, string? detail = null, string? type = null, string? instance = null, System.Collections.Generic.IDictionary<string, object?>? extensions = null) { }
         public Mockly.SequencedResponseBuilder RespondsWithStatus(System.Net.HttpStatusCode statusCode) { }
         public Mockly.SequencedResponseBuilder RespondsWithStream(System.IO.Stream stream, string contentType) { }
+        public Mockly.RequestMockResponseBuilder ThrowsException(System.Exception exception) { }
+        public Mockly.RequestMockResponseBuilder ThrowsException<TException>()
+            where TException : System.Exception, new () { }
+        public Mockly.RequestMockResponseBuilder TimesOut() { }
         public Mockly.RequestMockBuilder TreatBodyAsTextual() { }
         public Mockly.RequestMockBuilder Using(System.Text.Json.JsonSerializerOptions options) { }
         public Mockly.RequestMockBuilder With(System.Func<Mockly.RequestInfo, System.Threading.Tasks.Task<bool>> matcher, [System.Runtime.CompilerServices.CallerArgumentExpression("matcher")] string? matcherText = null) { }

--- a/Mockly.Specs/HttpMockSpecs.cs
+++ b/Mockly.Specs/HttpMockSpecs.cs
@@ -4713,5 +4713,166 @@ public class HttpMockSpecs
                 .WithMessage("*form field \"grant_type\" matches \"client_credentials\"*");
         }
     }
+
+    public class WhenSimulatingNetworkFailures
+    {
+        [Fact]
+        public async Task A_thrown_transport_exception_surfaces_to_the_caller()
+        {
+            // Arrange
+            var mock = new HttpMock();
+            mock.ForGet().WithPath("/flaky").ThrowsException<HttpRequestException>();
+
+            var client = mock.GetClient();
+
+            // Act
+            Func<Task> act = () => client.GetAsync("https://localhost/flaky");
+
+            // Assert
+            await act.Should().ThrowAsync<HttpRequestException>();
+        }
+
+        [Fact]
+        public async Task A_specific_exception_instance_is_thrown_to_the_caller()
+        {
+            // Arrange
+            var mock = new HttpMock();
+            var failure = new HttpRequestException("connection reset");
+            mock.ForGet().WithPath("/flaky").ThrowsException(failure);
+
+            var client = mock.GetClient();
+
+            // Act
+            Func<Task> act = () => client.GetAsync("https://localhost/flaky");
+
+            // Assert
+            (await act.Should().ThrowAsync<HttpRequestException>())
+                .Which.Message.Should().Be("connection reset");
+        }
+
+        [Fact]
+        public async Task A_null_exception_is_rejected()
+        {
+            // Arrange
+            var mock = new HttpMock();
+
+            // Act
+            Action act = () => mock.ForGet().WithPath("/flaky").ThrowsException(null!);
+
+            // Assert
+            act.Should().Throw<ArgumentNullException>();
+        }
+
+        [Fact]
+        public async Task Timing_out_throws_a_task_cancelled_exception()
+        {
+            // Arrange
+            var mock = new HttpMock();
+            mock.ForGet().WithPath("/slow").TimesOut();
+
+            var client = mock.GetClient();
+
+            // Act
+            Func<Task> act = () => client.GetAsync("https://localhost/slow");
+
+            // Assert
+            await act.Should().ThrowAsync<TaskCanceledException>();
+        }
+
+        [Fact]
+        public async Task The_failed_call_is_still_captured_in_the_requests()
+        {
+            // Arrange
+            var mock = new HttpMock();
+            mock.ForGet().WithPath("/flaky").ThrowsException<HttpRequestException>();
+
+            var client = mock.GetClient();
+
+            // Act
+            Func<Task> act = () => client.GetAsync("https://localhost/flaky");
+            await act.Should().ThrowAsync<HttpRequestException>();
+
+            // Assert
+            mock.Requests.Should().ContainSingle();
+            CapturedRequest captured = mock.Requests.Single();
+            captured.WasExpected.Should().BeTrue();
+            captured.Path.Should().Be("/flaky");
+            captured.SimulatedFailure.Should().BeOfType<HttpRequestException>();
+        }
+
+        [Fact]
+        public async Task The_failed_call_is_collected_in_a_request_collection()
+        {
+            // Arrange
+            var mock = new HttpMock();
+            var collected = new RequestCollection();
+            mock.ForGet().WithPath("/flaky").CollectingRequestsIn(collected).ThrowsException<HttpRequestException>();
+
+            var client = mock.GetClient();
+
+            // Act
+            Func<Task> act = () => client.GetAsync("https://localhost/flaky");
+            await act.Should().ThrowAsync<HttpRequestException>();
+
+            // Assert
+            collected.Should().ContainSingle();
+            collected.Single().SimulatedFailure.Should().BeOfType<HttpRequestException>();
+        }
+
+        [Fact]
+        public async Task A_simulated_failure_limited_to_once_only_applies_to_the_first_call()
+        {
+            // Arrange
+            var mock = new HttpMock();
+            mock.ForGet().WithPath("/flaky").ThrowsException<HttpRequestException>().Once();
+
+            var client = mock.GetClient();
+
+            // Act
+            Func<Task> firstCall = () => client.GetAsync("https://localhost/flaky");
+            await firstCall.Should().ThrowAsync<HttpRequestException>();
+
+            // Assert: the second call no longer matches the exhausted mock
+            Func<Task> secondCall = () => client.GetAsync("https://localhost/flaky");
+            await secondCall.Should().ThrowAsync<UnexpectedRequestException>();
+        }
+
+        [Fact]
+        public async Task A_simulated_failure_limited_to_a_number_of_times_applies_to_each_call()
+        {
+            // Arrange
+            var mock = new HttpMock();
+            mock.ForGet().WithPath("/flaky").ThrowsException<HttpRequestException>().Times(2);
+
+            var client = mock.GetClient();
+
+            // Act + Assert: both configured calls fail as simulated failures
+            Func<Task> firstCall = () => client.GetAsync("https://localhost/flaky");
+            await firstCall.Should().ThrowAsync<HttpRequestException>();
+
+            Func<Task> secondCall = () => client.GetAsync("https://localhost/flaky");
+            await secondCall.Should().ThrowAsync<HttpRequestException>();
+
+            mock.AllMocksInvoked.Should().BeTrue();
+        }
+
+        [Fact]
+        public async Task A_buggy_responder_still_results_in_a_500_response()
+        {
+            // Arrange
+            var mock = new HttpMock();
+            mock.ForGet().WithPath("/bug").RespondsWith(new Func<RequestInfo, HttpResponseMessage>(
+                _ => throw new InvalidOperationException("boom")));
+
+            var client = mock.GetClient();
+
+            // Act
+            var response = await client.GetAsync("https://localhost/bug");
+
+            // Assert: genuine responder bugs keep the existing 500 behavior rather than propagating
+            response.StatusCode.Should().Be(HttpStatusCode.InternalServerError);
+        }
+    }
+
 }
 

--- a/Mockly/CapturedRequest.cs
+++ b/Mockly/CapturedRequest.cs
@@ -14,6 +14,18 @@ public class CapturedRequest(RequestInfo request)
     public HttpResponseMessage Response { get; internal set; } = new();
 
     /// <summary>
+    /// Gets the exception that was thrown to simulate a network-level failure for this request, or <c>null</c>
+    /// when the request produced a regular response.
+    /// </summary>
+    /// <remarks>
+    /// This is set when the matching mock was configured with one of the simulated-failure methods such as
+    /// <c>ThrowsException</c> or <c>TimesOut</c>. When set, the HTTP pipeline propagates this exception to the
+    /// <see cref="HttpClient"/> caller, and <see cref="Response"/> does not represent a response that was actually
+    /// returned to the caller.
+    /// </remarks>
+    public Exception? SimulatedFailure { get; internal set; }
+
+    /// <summary>
     /// The mock that handled this request, if any.
     /// </summary>
     internal RequestMock? Mock { get; set; }

--- a/Mockly/HttpMock.cs
+++ b/Mockly/HttpMock.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Net;
+using System.Runtime.ExceptionServices;
 using System.Text;
 using Mockly.Common;
 #if NET472_OR_GREATER
@@ -293,6 +294,11 @@ public class HttpMock
         }
 
         Requests.Add(capturedRequest);
+
+        if (capturedRequest.SimulatedFailure is not null)
+        {
+            ExceptionDispatchInfo.Capture(capturedRequest.SimulatedFailure).Throw();
+        }
 
         if (!foundMatch && FailOnUnexpectedCalls)
         {

--- a/Mockly/RequestMock.cs
+++ b/Mockly/RequestMock.cs
@@ -106,6 +106,13 @@ public class RequestMock
     internal TimeSpan? Delay { get; set; }
 
     /// <summary>
+    /// Gets the responder that represents an intentionally simulated transport failure, if configured.
+    /// When set, the asynchronous response path records the request and then signals the HTTP pipeline to
+    /// propagate the produced exception to the caller instead of converting it into a <c>500</c> response.
+    /// </summary>
+    internal SimulatedFailureResponder? SimulatedFailure { get; init; }
+
+    /// <summary>
     /// Gets the collection that receives every <see cref="CapturedRequest"/> handled by this mock.
     /// When <c>null</c>, captured requests are not stored.
     /// </summary>
@@ -481,6 +488,16 @@ public class RequestMock
             Timestamp = DateTime.UtcNow
         };
 
+        if (SimulatedFailure is not null)
+        {
+            await ApplyConfiguredDelayAsync(cancellationToken);
+
+            capturedRequest.SimulatedFailure = SimulatedFailure.CreateException();
+            RequestCollection?.Add(capturedRequest);
+
+            return capturedRequest;
+        }
+
         try
         {
             capturedRequest.Response = ApplyResponseMutators(await InvokeResponderAsync(request, invocationIndex, cancellationToken));
@@ -510,10 +527,7 @@ public class RequestMock
     /// </summary>
     private async Task<HttpResponseMessage> InvokeResponderAsync(RequestInfo request, int invocationIndex, CancellationToken cancellationToken)
     {
-        if (Delay is { } delay && delay > TimeSpan.Zero)
-        {
-            await Task.Delay(delay, cancellationToken);
-        }
+        await ApplyConfiguredDelayAsync(cancellationToken);
 
         return await GetResponderForInvocation(invocationIndex)(request, cancellationToken);
     }
@@ -566,6 +580,17 @@ public class RequestMock
         }
 
         return response;
+    }
+
+    /// <summary>
+    /// Awaits the configured <see cref="Delay"/> (if any), honoring the supplied <paramref name="cancellationToken"/>.
+    /// </summary>
+    private async Task ApplyConfiguredDelayAsync(CancellationToken cancellationToken)
+    {
+        if (Delay is { } delay && delay > TimeSpan.Zero)
+        {
+            await Task.Delay(delay, cancellationToken);
+        }
     }
 
     /// <summary>

--- a/Mockly/RequestMockBuilder.cs
+++ b/Mockly/RequestMockBuilder.cs
@@ -1030,5 +1030,76 @@ public class RequestMockBuilder
             _ => "application/octet-stream"
         };
     }
+
+    /// <summary>
+    /// Configures the mock to simulate a network-level failure by throwing the specified <paramref name="exception"/>
+    /// instead of returning a response.
+    /// </summary>
+    /// <remarks>
+    /// The exception is propagated to the <see cref="System.Net.Http.HttpClient"/> caller rather than being converted
+    /// into a <c>500 Internal Server Error</c> response, allowing tests to verify retry, circuit-breaker and other
+    /// resilience behavior. The matching request is still recorded in <see cref="HttpMock.Requests"/> before the
+    /// exception is thrown. The same exception instance is thrown on every matching invocation.
+    /// </remarks>
+    /// <param name="exception">The exception to throw for a matching request.</param>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="exception"/> is <c>null</c>.</exception>
+    public RequestMockResponseBuilder ThrowsException(Exception exception)
+    {
+        if (exception is null)
+        {
+            throw new ArgumentNullException(nameof(exception));
+        }
+
+        return RespondsWithSimulatedFailure(() => exception);
+    }
+
+    /// <summary>
+    /// Configures the mock to simulate a network-level failure by throwing a freshly constructed
+    /// <typeparamref name="TException"/> instead of returning a response.
+    /// </summary>
+    /// <remarks>
+    /// A new instance of <typeparamref name="TException"/> is created for every matching invocation. The exception is
+    /// propagated to the <see cref="System.Net.Http.HttpClient"/> caller rather than being converted into a
+    /// <c>500 Internal Server Error</c> response. The matching request is still recorded in
+    /// <see cref="HttpMock.Requests"/> before the exception is thrown.
+    /// </remarks>
+    /// <typeparam name="TException">The type of exception to throw for a matching request.</typeparam>
+    public RequestMockResponseBuilder ThrowsException<TException>()
+        where TException : Exception, new()
+    {
+        return RespondsWithSimulatedFailure(static () => new TException());
+    }
+
+    /// <summary>
+    /// Configures the mock to simulate an <see cref="System.Net.Http.HttpClient"/> timeout by throwing a
+    /// <see cref="TaskCanceledException"/> instead of returning a response.
+    /// </summary>
+    /// <remarks>
+    /// This mimics the behavior of a real <see cref="System.Net.Http.HttpClient"/> whose request exceeds its
+    /// configured timeout. The exception is propagated to the caller and the matching request is still recorded in
+    /// <see cref="HttpMock.Requests"/> before the exception is thrown.
+    /// </remarks>
+    public RequestMockResponseBuilder TimesOut()
+    {
+        return RespondsWithSimulatedFailure(static () => new TaskCanceledException());
+    }
+
+    private RequestMockResponseBuilder RespondsWithSimulatedFailure(Func<Exception> exceptionFactory)
+    {
+        var mock = new RequestMock
+        {
+            Method = Method,
+            PathPattern = pathPattern,
+            QueryPattern = queryPattern,
+            Scheme = scheme,
+            HostPattern = hostPattern,
+            CustomMatchers = customMatchers,
+            RequestCollection = requestCollection,
+            SimulatedFailure = new SimulatedFailureResponder(exceptionFactory)
+        };
+
+        mockBuilder.AddMock(mock);
+        return new RequestMockResponseBuilder(mock);
+    }
 }
 

--- a/Mockly/SimulatedFailureResponder.cs
+++ b/Mockly/SimulatedFailureResponder.cs
@@ -1,0 +1,25 @@
+namespace Mockly;
+
+/// <summary>
+/// Dedicated responder that represents an intentionally simulated transport failure.
+/// </summary>
+/// <remarks>
+/// Unlike a regular responder, the exception produced by this responder is propagated to the
+/// <see cref="System.Net.Http.HttpClient"/> caller by the HTTP pipeline instead of being turned into a
+/// <c>500 Internal Server Error</c> response. This allows tests to verify retry, circuit-breaker and other
+/// resilience behavior.
+/// </remarks>
+internal sealed class SimulatedFailureResponder
+{
+    private readonly Func<Exception> exceptionFactory;
+
+    public SimulatedFailureResponder(Func<Exception> exceptionFactory)
+    {
+        this.exceptionFactory = exceptionFactory;
+    }
+
+    /// <summary>
+    /// Creates the exception to throw for a matching request.
+    /// </summary>
+    public Exception CreateException() => exceptionFactory();
+}


### PR DESCRIPTION
Closes #116

## Stacking

This is the top of a 3-PR stack and targets `dennisdoomen/response-latency-after`:

- Stacks on **#134** (issue #117 — response latency / `After()`)
- Which stacks on **#132** (issue #120 — async responder pipeline / `CancellationToken` threading)

It builds on the async responder path (`TrackRequestAsync`, `CancellationToken` flowing from `SendAsync` → `HandleRequest` → `RequestMock`) introduced in those PRs and does not re-implement them.

## Summary

Adds first-class support for simulating network-level failures so tests can exercise retry, circuit-breaker and error-handling code.

Previously the pipeline swallowed every responder exception and turned it into a `500` response, so there was no way to simulate a thrown transport error. This change introduces a dedicated **simulated-failure responder** that the async pipeline *propagates* to the `HttpClient` caller instead of catching:

- A new internal `SimulatedFailureResponder` type represents an intentionally simulated failure.
- `RequestMock.TrackRequestAsync` records the request (incrementing the invocation count and adding it to any request collection) and returns the captured request carrying the exception, rather than throwing inline. This guarantees the failed call is recorded in `HttpMock.Requests` (as expected/handled) *before* the exception reaches the caller.
- `HttpMock.HandleRequest` rethrows the captured exception via `ExceptionDispatchInfo` after recording it.
- The existing `try/catch` that converts responder exceptions into a `500` is carefully scoped so genuine bugs in user `RespondsWith` responders **keep** the current `500` behavior, while intentionally-simulated failures propagate.
- `Once()` / `Times(n)` and `After()` continue to apply to simulated failures.

## New public API

```csharp
RequestMockResponseBuilder ThrowsException(Exception exception);
RequestMockResponseBuilder ThrowsException<TException>() where TException : Exception, new();
RequestMockResponseBuilder TimesOut(); // throws TaskCanceledException, mimicking an HttpClient timeout
```

Plus `CapturedRequest.SimulatedFailure` (`Exception?`) so a captured entry can be inspected to tell a simulated throw apart from an unexpected `500`.

Usage:

```csharp
mock.ForGet().WithPath("/flaky").ThrowsException<HttpRequestException>();
mock.ForGet().WithPath("/slow").TimesOut();
```

This is additive and backward-compatible. The API verification baselines (`net8.0`, `net472`) were regenerated via `AcceptApiChanges.ps1`.

## Tests

New `WhenSimulatingNetworkFailures` spec class (xUnit + FluentAssertions, AAA) covering:

- `HttpRequestException` surfaces to the `HttpClient` caller (generic and specific-instance overloads)
- `TimesOut()` throws `TaskCanceledException`
- the failed call is captured in `HttpMock.Requests` and in a `CollectingRequestsIn` collection
- `Once()` / `Times(n)` still apply
- a genuinely buggy responder still results in a `500`
- null exception is rejected

All 108 specs pass on both `net8.0` and `net472`; Release build (warnings-as-errors, all analyzers) is clean.

## Follow-up

Issue #116 also describes a companion `CapturedRequestAssertions.BeASimulatedFailure()` assertion in the **separate** `dennisdoomen/fluentassertions.mockly` repo (v7/v8 via `Shared/`). That is not part of this repo/workspace and needs its own PR; the new public `CapturedRequest.SimulatedFailure` property is exposed here so that assertion can be built on top of it.