### PR TITLE
Upgrade dependencies and move to xUnit v3

### DIFF
--- a/Mockly.ApiVerificationTests/Mockly.ApiVerificationTests.csproj
+++ b/Mockly.ApiVerificationTests/Mockly.ApiVerificationTests.csproj
@@ -5,19 +5,19 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
     <PackageReference Include="Pathy" Version="1.7.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.v3" Version="3.2.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="PublicApiGenerator" Version="11.5.4" />
-    <PackageReference Include="Verify.DiffPlex" Version="3.1.2" />
-    <PackageReference Include="Verify.Xunit" Version="31.12.5" />
+    <PackageReference Include="Verify.DiffPlex" Version="3.2.0" />
+    <PackageReference Include="Verify.XunitV3" Version="31.19.0" />
     <PackageReference Include="System.Net.Http" Version="4.3.4"/>
     <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1"/>
   </ItemGroup>

--- a/Mockly.Specs/Mockly.Specs.csproj
+++ b/Mockly.Specs/Mockly.Specs.csproj
@@ -9,10 +9,6 @@
       <AnalysisLevel>6.0</AnalysisLevel>
     </PropertyGroup>
 
-    <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
-      <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
-    </ItemGroup>
-
   <ItemGroup Condition=" '$(TargetFramework)' == 'net472' ">
     <PackageReference Include="System.Text.Json" Version="8.0.6" />
   </ItemGroup>
@@ -35,6 +31,10 @@
 
     <ItemGroup>
       <ProjectReference Include="..\Mockly\Mockly.csproj" />
+    </ItemGroup>
+
+    <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
+      <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
     </ItemGroup>
 
 

--- a/Mockly/Mockly.csproj
+++ b/Mockly/Mockly.csproj
@@ -48,7 +48,7 @@
   </ItemGroup>
 
   <ItemGroup Label="Dependencies">
-    <PackageReference Include="PolySharp" Version="1.15.0">
+    <PackageReference Include="PolySharp" Version="1.16.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
This PR upgrades several dependencies in the project:
- `Microsoft.NET.Test.Sdk` to 18.6.0
- `xunit` to `xunit.v3` 3.2.2
- `Verify.DiffPlex` to 3.2.0
- `Verify.Xunit` to `Verify.XunitV3` 31.19.0
- `PolySharp` to 1.16.0