### PR TITLE
Add AI hint to README for Agent Skill usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,6 +241,9 @@ mock.Should().HaveAllRequestsCalled();
 
 **For complete documentation and advanced examples, visit [mockly.org](https://mockly.org/)**
 
+> [!TIP]
+> This project ships an [Agent Skill](https://agentskills.io) that helps AI Coding Agents use Mockly effectively. [This file](./SKILL.md) will be stored in the `.agents/skills/mockly` directory of your project when you build the project. You can disable this behavior by setting `<MocklySkill>false</MocklySkill>` in your project or `Directory.Build.props`.
+
 ## Building
 
 To build this repository locally, you need:


### PR DESCRIPTION
## Summary
- add a README tip that explains Mockly ships an Agent Skill
- link to `SKILL.md` and document the `.agents/skills/mockly` copy behavior
- mention the `<MocklySkill>false</MocklySkill>` opt-out

Closes #148