### PR TITLE
Add RawBody to RequestInfo for non-text payload validation

### DIFF
--- a/Mockly.ApiVerificationTests/ApprovedApi/net472.verified.txt
+++ b/Mockly.ApiVerificationTests/ApprovedApi/net472.verified.txt
@@ -13,6 +13,7 @@ namespace Mockly
         public System.Net.Http.HttpMethod Method { get; }
         public string Path { get; }
         public string Query { get; }
+        public byte[]? RawBody { get; }
         public System.Net.Http.HttpResponseMessage Response { get; }
         public string Scheme { get; }
         public int Sequence { get; set; }
@@ -56,12 +57,6 @@ namespace Mockly
     {
         T Build();
     }
-    public class Matcher
-    {
-        public Matcher(System.Func<Mockly.RequestInfo, System.Threading.Tasks.Task<bool>> predicate, string? displayText) { }
-        public System.Threading.Tasks.Task<bool> IsMatch(Mockly.RequestInfo request) { }
-        public override string ToString() { }
-    }
     public class RequestCollection : System.Collections.Generic.IEnumerable<Mockly.CapturedRequest>, System.Collections.IEnumerable
     {
         public RequestCollection() { }
@@ -74,12 +69,13 @@ namespace Mockly
     }
     public class RequestInfo
     {
-        public RequestInfo(System.Net.Http.HttpRequestMessage request, string? body) { }
+        public RequestInfo(System.Net.Http.HttpRequestMessage request, byte[]? rawBody) { }
         public string? Body { get; }
         public string? ContentType { get; }
         public System.Net.Http.Headers.HttpRequestHeaders Headers { get; }
         public System.Net.Http.HttpMethod Method { get; set; }
         public System.Collections.Generic.IDictionary<string, object?> Properties { get; }
+        public byte[]? RawBody { get; }
         public System.Uri? Uri { get; }
         public System.Version Version { get; set; }
         public bool IsBodyLikelyTextual() { }
@@ -91,7 +87,6 @@ namespace Mockly
     public class RequestMock
     {
         public RequestMock() { }
-        public System.Collections.Generic.IEnumerable<Mockly.Matcher> CustomMatchers { get; }
         public string? HostPattern { get; set; }
         public int InvocationCount { get; }
         public uint? MaxInvocations { get; }

--- a/Mockly.ApiVerificationTests/ApprovedApi/net8.0.verified.txt
+++ b/Mockly.ApiVerificationTests/ApprovedApi/net8.0.verified.txt
@@ -14,6 +14,7 @@ namespace Mockly
         public System.Net.Http.HttpRequestOptions Options { get; }
         public string Path { get; }
         public string Query { get; }
+        public byte[]? RawBody { get; }
         public System.Net.Http.HttpResponseMessage Response { get; }
         public string Scheme { get; }
         public int Sequence { get; set; }
@@ -58,12 +59,6 @@ namespace Mockly
     {
         T Build();
     }
-    public class Matcher
-    {
-        public Matcher(System.Func<Mockly.RequestInfo, System.Threading.Tasks.Task<bool>> predicate, string? displayText) { }
-        public System.Threading.Tasks.Task<bool> IsMatch(Mockly.RequestInfo request) { }
-        public override string ToString() { }
-    }
     public class RequestCollection : System.Collections.Generic.IEnumerable<Mockly.CapturedRequest>, System.Collections.IEnumerable
     {
         public RequestCollection() { }
@@ -76,12 +71,13 @@ namespace Mockly
     }
     public class RequestInfo
     {
-        public RequestInfo(System.Net.Http.HttpRequestMessage request, string? body) { }
+        public RequestInfo(System.Net.Http.HttpRequestMessage request, byte[]? rawBody) { }
         public string? Body { get; }
         public string? ContentType { get; }
         public System.Net.Http.Headers.HttpRequestHeaders Headers { get; }
         public System.Net.Http.HttpMethod Method { get; set; }
         public System.Net.Http.HttpRequestOptions Options { get; }
+        public byte[]? RawBody { get; }
         public System.Uri? Uri { get; }
         public System.Version Version { get; set; }
         public System.Net.Http.HttpVersionPolicy VersionPolicy { get; set; }
@@ -94,7 +90,6 @@ namespace Mockly
     public class RequestMock
     {
         public RequestMock() { }
-        public System.Collections.Generic.IEnumerable<Mockly.Matcher> CustomMatchers { get; }
         public string? HostPattern { get; set; }
         public int InvocationCount { get; }
         public uint? MaxInvocations { get; }

--- a/Mockly.Specs/HttpMockSpecs.cs
+++ b/Mockly.Specs/HttpMockSpecs.cs
@@ -1051,6 +1051,7 @@ public class HttpMockSpecs
             // Assert
             request.Should().NotBeNull();
             request.Body.Should().BeNull();
+            request.RawBody.Should().BeNull();
         }
 
         [Fact]
@@ -1105,6 +1106,59 @@ public class HttpMockSpecs
             requests.IsEmpty.Should().BeFalse();
             requests.Count.Should().Be(1);
             requests.Should().ContainSingle().Which.ToString().Should().Be("PATCH https://localhost/api/update");
+        }
+
+        [Fact]
+        public async Task Exposes_the_textual_body_of_a_captured_request()
+        {
+            // Arrange
+            var mock = new HttpMock();
+            var requests = new RequestCollection();
+
+            mock.ForPost()
+                .WithPath("/api/update")
+                .CollectingRequestsIn(requests)
+                .RespondsWithStatus(HttpStatusCode.NoContent);
+
+            var client = mock.GetClient();
+
+            // Act
+            await client.PostAsync("https://localhost/api/update",
+                new StringContent("hello", Encoding.UTF8, "text/plain"));
+
+            // Assert
+            CapturedRequest capturedRequest = requests.Should().ContainSingle().Which;
+            capturedRequest.Body.Should().Be("hello");
+            capturedRequest.RawBody.Should().Equal("hello"u8.ToArray());
+        }
+
+        [Fact]
+        public async Task Exposes_the_raw_bytes_of_a_binary_captured_request()
+        {
+            // Arrange
+            var mock = new HttpMock();
+            var requests = new RequestCollection();
+
+            mock.ForPost()
+                .WithPath("/api/update")
+                .CollectingRequestsIn(requests)
+                .RespondsWithStatus(HttpStatusCode.NoContent);
+
+            var client = mock.GetClient();
+
+            // Act
+            await client.PostAsync("https://localhost/api/update", new ByteArrayContent([1, 2, 3])
+            {
+                Headers =
+                {
+                    ContentType = new MediaTypeHeaderValue("application/octet-stream")
+                }
+            });
+
+            // Assert
+            CapturedRequest capturedRequest = requests.Should().ContainSingle().Which;
+            capturedRequest.Body.Should().BeNull();
+            capturedRequest.RawBody.Should().Equal(1, 2, 3);
         }
 
         [Fact]
@@ -2060,8 +2114,43 @@ public class HttpMockSpecs
             // Assert
             capturedInfo.Should().NotBeNull();
             capturedInfo.Method.Should().Be(HttpMethod.Post);
-            capturedInfo.Uri.AbsolutePath.Should().Be("/api/info");
+            capturedInfo.Uri.Should().NotBeNull();
+            capturedInfo.Uri!.AbsolutePath.Should().Be("/api/info");
             capturedInfo.Body.Should().Be("hello");
+            capturedInfo.RawBody.Should().Equal("hello"u8.ToArray());
+        }
+
+        [Fact]
+        public async Task An_async_responder_receives_binary_request_body_as_raw_bytes()
+        {
+            // Arrange
+            var mock = new HttpMock();
+            RequestInfo capturedInfo = null;
+
+            mock.ForPost()
+                .WithPath("/api/binary-info")
+                .RespondsWith(async request =>
+                {
+                    capturedInfo = request;
+                    await Task.Yield();
+                    return new HttpResponseMessage(HttpStatusCode.OK);
+                });
+
+            var client = mock.GetClient();
+
+            // Act
+            await client.PostAsync("https://localhost/api/binary-info", new ByteArrayContent([1, 2, 3])
+            {
+                Headers =
+                {
+                    ContentType = new MediaTypeHeaderValue("application/octet-stream")
+                }
+            });
+
+            // Assert
+            capturedInfo.Should().NotBeNull();
+            capturedInfo.Body.Should().BeNull();
+            capturedInfo.RawBody.Should().Equal(1, 2, 3);
         }
 
         [Fact]
@@ -3427,7 +3516,7 @@ public class HttpMockSpecs
         }
 
         [Fact]
-        public void The_Responder_property_still_exposes_the_first_response()
+        public void The_responder_property_still_exposes_the_first_response()
         {
             // Arrange
             var mock = new HttpMock();
@@ -3437,7 +3526,7 @@ public class HttpMockSpecs
 
             // Act
             var uninvoked = mock.GetUninvokedMocks().First();
-            var request = new RequestInfo(new HttpRequestMessage(HttpMethod.Get, "https://localhost/resource"), body: null);
+            var request = new RequestInfo(new HttpRequestMessage(HttpMethod.Get, "https://localhost/resource"), rawBody: null);
             var firstResponse = uninvoked.Responder(request);
 
             // Assert
@@ -4469,5 +4558,4 @@ public class HttpMockSpecs
         }
     }
 }
-
 

--- a/Mockly/CapturedRequest.cs
+++ b/Mockly/CapturedRequest.cs
@@ -73,6 +73,14 @@ public class CapturedRequest(RequestInfo request)
     }
 
     /// <summary>
+    /// Gets the raw body bytes of the captured HTTP request.
+    /// </summary>
+    public byte[]? RawBody
+    {
+        get => request.RawBody;
+    }
+
+    /// <summary>
     /// The collection of HTTP request headers associated with the captured request.
     /// </summary>
     public HttpRequestHeaders Headers

--- a/Mockly/HttpMock.cs
+++ b/Mockly/HttpMock.cs
@@ -328,7 +328,8 @@ public class HttpMock
 
         var messageBuilder = new StringBuilder();
         messageBuilder.AppendLine("Unexpected request to:");
-        messageBuilder.AppendLine($"  {request.Method} {request.Uri} with body of {request.Body?.Length ?? 0} bytes");
+        int bodyLength = request.RawBody?.Length ?? request.Body?.Length ?? 0;
+        messageBuilder.AppendLine($"  {request.Method} {request.Uri} with body of {bodyLength} bytes");
 
         messageBuilder.AppendLine();
         messageBuilder.AppendLine("Note that you can further inspect the executed requests through the HttpMock.Requests property.");
@@ -370,12 +371,12 @@ public class HttpMock
             }
         }
 
-        if (request.Body is not null && request.Body.Length > 0)
+        if ((request.RawBody?.Length ?? 0) > 0 || !string.IsNullOrEmpty(request.Body))
         {
             messageBuilder.AppendLine();
             messageBuilder.AppendLine($"Body ({request.ContentType}):");
 
-            if (request.IsBodyLikelyTextual())
+            if (request.IsBodyLikelyTextual() && request.Body is not null)
             {
                 messageBuilder.AppendLine($"  \"{request.Body}\"");
             }
@@ -394,14 +395,13 @@ public class HttpMock
     /// </summary>
     private async Task<RequestInfo> BuildRequestInfo(HttpRequestMessage httpRequest)
     {
-        string? body = null;
+        byte[]? rawBody = null;
         if (PrefetchBody && httpRequest.Content is not null)
         {
-            body = await httpRequest.Content.ReadAsStringAsync();
+            rawBody = await httpRequest.Content.ReadAsByteArrayAsync();
         }
 
-        var request = new RequestInfo(httpRequest, body);
-        return request;
+        return new RequestInfo(httpRequest, rawBody);
     }
 
     /// <summary>

--- a/Mockly/Matcher.cs
+++ b/Mockly/Matcher.cs
@@ -1,6 +1,6 @@
 namespace Mockly;
 
-public class Matcher(Func<RequestInfo, Task<bool>> predicate, string? displayText)
+internal class Matcher(Func<RequestInfo, Task<bool>> predicate, string? displayText)
 {
     public override string ToString() => displayText ?? "Custom matcher";
 

--- a/Mockly/RequestInfo.cs
+++ b/Mockly/RequestInfo.cs
@@ -1,18 +1,39 @@
 using System.Net.Http;
 using System.Net.Http.Headers;
+using System.Text;
 
 namespace Mockly;
 
-public class RequestInfo(HttpRequestMessage request, string? body)
+/// <summary>
+/// Provides information about a request that was captured by a mock.
+/// </summary>
+public class RequestInfo
 {
+    private readonly HttpRequestMessage request;
+
+    public RequestInfo(HttpRequestMessage request, byte[]? rawBody)
+    {
+        this.request = request;
+        RawBody = rawBody;
+        Body = DeserializeBodyIfTextual(rawBody);
+    }
+
+    /// <summary>
+    /// Gets the URI of the HTTP request, representing the full address, including the scheme, host, path, and query string, if present.
+    /// </summary>
     public Uri? Uri => request.RequestUri;
 
-    public string? Body { get; } = body;
+    public string? Body { get; }
+
+    /// <summary>
+    /// The request body as raw bytes, if prefetched.
+    /// </summary>
+    public byte[]? RawBody { get; }
 
     /// <summary>
     /// The content type of the request body, if any.
     /// </summary>
-    public string? ContentType { get; } = request.Content?.Headers.ContentType?.MediaType;
+    public string? ContentType => request.Content?.Headers.ContentType?.MediaType;
 
     public HttpRequestHeaders Headers
     {
@@ -102,5 +123,37 @@ public class RequestInfo(HttpRequestMessage request, string? body)
             "application/x-www-form-urlencoded" or
             "application/graphql" or
             "application/sql";
+    }
+
+    /// <summary>
+    /// Deserializes the provided raw body byte array into a textual representation if it is likely to be textual.
+    /// </summary>
+    private string? DeserializeBodyIfTextual(byte[]? rawBody)
+    {
+        if (rawBody is null || rawBody.Length == 0 || !IsBodyLikelyTextual())
+        {
+            return null;
+        }
+
+        Encoding encoding = GetEncoding() ?? Encoding.UTF8;
+        return encoding.GetString(rawBody);
+    }
+
+    private Encoding? GetEncoding()
+    {
+        string? charset = request.Content?.Headers.ContentType?.CharSet;
+        if (string.IsNullOrWhiteSpace(charset))
+        {
+            return null;
+        }
+
+        try
+        {
+            return Encoding.GetEncoding(charset);
+        }
+        catch (ArgumentException)
+        {
+            return null;
+        }
     }
 }

--- a/Mockly/RequestMock.cs
+++ b/Mockly/RequestMock.cs
@@ -60,7 +60,7 @@ public class RequestMock
     /// Gets the custom matchers that are evaluated in addition to the standard route criteria.
     /// All matchers must return <c>true</c> for the mock to match a request.
     /// </summary>
-    public IEnumerable<Matcher> CustomMatchers { get; internal init; } = [];
+    internal IEnumerable<Matcher> CustomMatchers { get; init; } = [];
 
     /// <summary>
     /// Gets or sets the responder used to produce a response for a matched request.

--- a/website/docs/advanced.md
+++ b/website/docs/advanced.md
@@ -192,6 +192,24 @@ capturedRequests.Count.Should().Be(2);
 capturedRequests.First().WasExpected.Should().BeTrue();
 ```
 
+### Inspecting the Captured Body
+
+Each `CapturedRequest` exposes the request body both as text (`Body`) and as raw bytes (`RawBody`):
+
+```csharp
+var capturedRequest = capturedRequests.First();
+
+// The body decoded as text, or null if it's not textual (see IsBodyLikelyTextual)
+capturedRequest.Body.Should().Be("hello");
+
+// The raw, undecoded bytes of the body
+capturedRequest.RawBody.Should().Equal(Encoding.UTF8.GetBytes("hello"));
+```
+
+:::info
+`Body` and `RawBody` are only populated when `HttpMock.PrefetchBody` is `true` (the default). See [Request Body Prefetching](#request-body-prefetching) above.
+:::
+
 ## Assertions
 
 Mockly provides extensive support for test assertions through **FluentAssertions**. For a full guide on available assertions for mocks, collections, and requests, see the [Assertions](./assertions.md) page.


### PR DESCRIPTION
## Summary
Add raw request body bytes to RequestInfo and CapturedRequest so non-text payloads can be validated.

## Changes
- add RequestInfo.RawBody and a constructor overload accepting raw bytes
- derive textual Body from prefetched bytes for textual media types to avoid dual payload sources
- prefetch request content as bytes in HttpMock
- expose CapturedRequest.RawBody
- keep unexpected-request diagnostics consistent for binary payloads
- add/adjust specs for textual, binary, and PrefetchBody = false scenarios
- update API approval baselines for 
et8.0 and 
et472

Closes #156