### PR TITLE
Use UTF-8 string literals instead of Encoding.GetBytes in tests

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -2,6 +2,7 @@ changelog:
   exclude:
     labels:
       - changelog-ignore
+      - skip-release-notes
     authors:
       - dependabot
   categories:

--- a/Mockly.Specs/HttpMockSpecs.cs
+++ b/Mockly.Specs/HttpMockSpecs.cs
@@ -893,7 +893,7 @@ public class HttpMockSpecs
 
             var client = mock.GetClient();
 
-            var content = new ByteArrayContent(Encoding.UTF8.GetBytes("a body with something in it"));
+            var content = new ByteArrayContent("a body with something in it"u8.ToArray());
             content.Headers.ContentType = new MediaTypeHeaderValue("application/octet-stream");
 
             // Act
@@ -917,7 +917,7 @@ public class HttpMockSpecs
 
             var client = mock.GetClient();
 
-            var content = new ByteArrayContent(Encoding.UTF8.GetBytes("a body with something in it"));
+            var content = new ByteArrayContent("a body with something in it"u8.ToArray());
             content.Headers.ContentType = new MediaTypeHeaderValue("application/octet-stream");
 
             // Act


### PR DESCRIPTION
## Changes

### 1. GitHub Advanced Security follow-up

InspectCode flagged two `Encoding.UTF8.GetBytes(...)` calls in the new tests added by #163, suggesting UTF-8 string literals instead. Replaced with `"..."u8.ToArray()` in `Cannot_match_body_with_an_unrecognized_content_type_by_default` and `Can_force_a_body_with_an_unrecognized_content_type_to_be_treated_as_textual`, consistent with existing usage elsewhere in `HttpMockSpecs.cs`.

Note: #163 was merged before these code-scanning comments were addressed, so this is a small follow-up PR against `main`.

### 2. Release notes template

Added `skip-release-notes` to `.github/release.yml`'s `changelog.exclude.labels`, so PRs labeled `skip-release-notes` are excluded from auto-generated release notes (same mechanism already used for `changelog-ignore`).

## Testing

- `dotnet test --filter "FullyQualifiedName~AdvancedMatching"` passes on both net8.0 and net472.
- `.github/release.yml` is a config-only change (no build/test applicable).

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>
