### PR TITLE
Fix dependabot author exclusion in release notes

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -4,7 +4,7 @@ changelog:
       - changelog-ignore
       - skip-release-notes
     authors:
-      - dependabot
+      - dependabot[bot]
   categories:
     - title: Breaking Changes
       labels:


### PR DESCRIPTION
GitHub's `exclude.authors` in `.github/release.yml` matches on the exact login, which for Dependabot PRs is `dependabot[bot]`, not `dependabot`. As a result, dependabot PRs were still being included in auto-generated release notes despite the existing exclusion entry.

This updates the config to use the correct login so dependabot PRs are properly excluded from release notes.