### PR TITLE
Add record and replay support

### DIFF
--- a/Mockly.ApiVerificationTests/ApiApproval.cs
+++ b/Mockly.ApiVerificationTests/ApiApproval.cs
@@ -27,7 +27,7 @@ public class ApiApproval
         var configuration = typeof(ApiApproval).Assembly.GetCustomAttribute<AssemblyConfigurationAttribute>()!.Configuration;
         var assemblyFile = SourcePath / "Mockly" / "bin" / configuration / framework / "Mockly.dll";
         var assembly = Assembly.LoadFile(assemblyFile);
-        var publicApi = assembly.GeneratePublicApi(options: null);
+        string publicApi = assembly.GeneratePublicApi(options: null).ReplaceLineEndings("\n");
 
         return Verifier
             .Verify(publicApi)

--- a/Mockly.ApiVerificationTests/ApprovedApi/net47.verified.txt
+++ b/Mockly.ApiVerificationTests/ApprovedApi/net47.verified.txt
@@ -27,6 +27,10 @@ namespace Mockly.Http
         public bool AllMocksInvoked { get; }
         public bool FailOnUnexpectedCalls { get; set; }
         public bool PrefetchBody { get; set; }
+        public Mockly.HttpMock KeepSensitiveRecordingValues() { }
+        public Mockly.HttpMock LoadRecordings(string path) { }
+        public Mockly.HttpMock PassThroughUnmatched() { }
+        public Mockly.HttpMock RecordingTo(string path) { }
         public Mockly.Http.RequestCollection Requests { get; }
         public void Clear() { }
         public Mockly.Http.RequestMockBuilder ForDelete() { }

--- a/Mockly.ApiVerificationTests/ApprovedApi/net472.verified.txt
+++ b/Mockly.ApiVerificationTests/ApprovedApi/net472.verified.txt
@@ -30,10 +30,6 @@ namespace Mockly
         public bool AllMocksInvoked { get; }
         public bool FailOnUnexpectedCalls { get; set; }
         public bool PrefetchBody { get; set; }
-        public Mockly.HttpMock KeepSensitiveRecordingValues() { }
-        public Mockly.HttpMock LoadRecordings(string path) { }
-        public Mockly.HttpMock PassThroughUnmatched() { }
-        public Mockly.HttpMock RecordingTo(string path) { }
         public Mockly.RequestCollection Requests { get; }
         public void Clear() { }
         public Mockly.RequestMockBuilder For(System.Net.Http.HttpMethod method) { }
@@ -57,6 +53,10 @@ namespace Mockly
         public System.Net.Http.HttpMessageHandler GetMessageHandler() { }
         public System.Collections.Generic.IEnumerable<Mockly.RequestMock> GetUninvokedMocks() { }
         public Mockly.RequestMockBuilder ImportFromCurl(string curlCommand) { }
+        public Mockly.HttpMock KeepSensitiveRecordingValues() { }
+        public Mockly.HttpMock LoadRecordings(string path) { }
+        public Mockly.HttpMock PassThroughUnmatched() { }
+        public Mockly.HttpMock RecordingTo(string path) { }
         public Mockly.HttpMock Reset() { }
     }
     public interface IResponseBuilder<out T>

--- a/Mockly.ApiVerificationTests/ApprovedApi/net472.verified.txt
+++ b/Mockly.ApiVerificationTests/ApprovedApi/net472.verified.txt
@@ -30,6 +30,10 @@ namespace Mockly
         public bool AllMocksInvoked { get; }
         public bool FailOnUnexpectedCalls { get; set; }
         public bool PrefetchBody { get; set; }
+        public Mockly.HttpMock KeepSensitiveRecordingValues() { }
+        public Mockly.HttpMock LoadRecordings(string path) { }
+        public Mockly.HttpMock PassThroughUnmatched() { }
+        public Mockly.HttpMock RecordingTo(string path) { }
         public Mockly.RequestCollection Requests { get; }
         public void Clear() { }
         public Mockly.RequestMockBuilder For(System.Net.Http.HttpMethod method) { }

--- a/Mockly.ApiVerificationTests/ApprovedApi/net8.0.verified.txt
+++ b/Mockly.ApiVerificationTests/ApprovedApi/net8.0.verified.txt
@@ -32,6 +32,10 @@ namespace Mockly
         public bool AllMocksInvoked { get; }
         public bool FailOnUnexpectedCalls { get; set; }
         public bool PrefetchBody { get; set; }
+        public Mockly.HttpMock KeepSensitiveRecordingValues() { }
+        public Mockly.HttpMock LoadRecordings(string path) { }
+        public Mockly.HttpMock PassThroughUnmatched() { }
+        public Mockly.HttpMock RecordingTo(string path) { }
         public Mockly.RequestCollection Requests { get; }
         public void Clear() { }
         public Mockly.RequestMockBuilder For(System.Net.Http.HttpMethod method) { }

--- a/Mockly.ApiVerificationTests/ApprovedApi/net8.0.verified.txt
+++ b/Mockly.ApiVerificationTests/ApprovedApi/net8.0.verified.txt
@@ -32,10 +32,6 @@ namespace Mockly
         public bool AllMocksInvoked { get; }
         public bool FailOnUnexpectedCalls { get; set; }
         public bool PrefetchBody { get; set; }
-        public Mockly.HttpMock KeepSensitiveRecordingValues() { }
-        public Mockly.HttpMock LoadRecordings(string path) { }
-        public Mockly.HttpMock PassThroughUnmatched() { }
-        public Mockly.HttpMock RecordingTo(string path) { }
         public Mockly.RequestCollection Requests { get; }
         public void Clear() { }
         public Mockly.RequestMockBuilder For(System.Net.Http.HttpMethod method) { }
@@ -59,6 +55,10 @@ namespace Mockly
         public System.Net.Http.HttpMessageHandler GetMessageHandler() { }
         public System.Collections.Generic.IEnumerable<Mockly.RequestMock> GetUninvokedMocks() { }
         public Mockly.RequestMockBuilder ImportFromCurl(string curlCommand) { }
+        public Mockly.HttpMock KeepSensitiveRecordingValues() { }
+        public Mockly.HttpMock LoadRecordings(string path) { }
+        public Mockly.HttpMock PassThroughUnmatched() { }
+        public Mockly.HttpMock RecordingTo(string path) { }
         public Mockly.HttpMock Reset() { }
     }
     public interface IResponseBuilder<out T>

--- a/Mockly.ApiVerificationTests/ApprovedApi/netstandard2.0.verified.txt
+++ b/Mockly.ApiVerificationTests/ApprovedApi/netstandard2.0.verified.txt
@@ -27,6 +27,10 @@ namespace Mockly.Http
         public bool AllMocksInvoked { get; }
         public bool FailOnUnexpectedCalls { get; set; }
         public bool PrefetchBody { get; set; }
+        public Mockly.HttpMock KeepSensitiveRecordingValues() { }
+        public Mockly.HttpMock LoadRecordings(string path) { }
+        public Mockly.HttpMock PassThroughUnmatched() { }
+        public Mockly.HttpMock RecordingTo(string path) { }
         public Mockly.Http.RequestCollection Requests { get; }
         public void Clear() { }
         public Mockly.Http.RequestMockBuilder ForDelete() { }

--- a/Mockly.ApiVerificationTests/ApprovedApi/netstandard2.1.verified.txt
+++ b/Mockly.ApiVerificationTests/ApprovedApi/netstandard2.1.verified.txt
@@ -27,6 +27,10 @@ namespace Mockly.Http
         public bool AllMocksInvoked { get; }
         public bool FailOnUnexpectedCalls { get; set; }
         public bool PrefetchBody { get; set; }
+        public Mockly.HttpMock KeepSensitiveRecordingValues() { }
+        public Mockly.HttpMock LoadRecordings(string path) { }
+        public Mockly.HttpMock PassThroughUnmatched() { }
+        public Mockly.HttpMock RecordingTo(string path) { }
         public Mockly.Http.RequestCollection Requests { get; }
         public void Clear() { }
         public Mockly.Http.RequestMockBuilder ForDelete() { }

--- a/Mockly.Specs/HttpMockSpecs.cs
+++ b/Mockly.Specs/HttpMockSpecs.cs
@@ -21,6 +21,20 @@ namespace Mockly.Specs;
 
 public class HttpMockSpecs
 {
+    /// <summary>
+    /// Writes a recording file asynchronously. <see cref="File.WriteAllTextAsync"/> is only available
+    /// starting with .NET Core, so net472 falls back to the synchronous overload.
+    /// </summary>
+    private static Task WriteRecordingAsync(string path, string contents)
+    {
+#if NET8_0_OR_GREATER
+        return File.WriteAllTextAsync(path, contents);
+#else
+        File.WriteAllText(path, contents);
+        return Task.CompletedTask;
+#endif
+    }
+
     public class BasicUsage
     {
         [Fact]
@@ -69,7 +83,7 @@ public class HttpMockSpecs
                   }
                 }
                 """;
-            File.WriteAllText(path, recording);
+            await WriteRecordingAsync(path, recording);
 
             try
             {
@@ -110,7 +124,8 @@ public class HttpMockSpecs
                         "response": {
                           "status": 202,
                           "headers": [
-                            { "name": "X-Recorded", "value": "true" }
+                            { "name": "X-Recorded", "value": "true" },
+                            { "name": "Content-Language", "value": "en-US" }
                           ],
                           "content": {
                             "mimeType": "application/json",
@@ -123,7 +138,7 @@ public class HttpMockSpecs
                   }
                 }
                 """;
-            File.WriteAllText(path, recording);
+            await WriteRecordingAsync(path, recording);
 
             try
             {
@@ -136,6 +151,7 @@ public class HttpMockSpecs
                 // Assert
                 response.StatusCode.Should().Be(HttpStatusCode.Accepted);
                 response.Headers.GetValues("X-Recorded").Should().ContainSingle("true");
+                response.Content.Headers.ContentLanguage.Should().ContainSingle("en-US");
                 (await response.Content.ReadAsStringAsync()).Should().Be("{\"ok\":true}");
             }
             finally
@@ -168,7 +184,7 @@ public class HttpMockSpecs
                   }
                 }
                 """;
-            File.WriteAllText(path, recording);
+            await WriteRecordingAsync(path, recording);
             var mock = new HttpMock { FailOnUnexpectedCalls = false }.LoadRecordings(path);
 
             try
@@ -181,6 +197,148 @@ public class HttpMockSpecs
                 // Assert
                 response.StatusCode.Should().Be(HttpStatusCode.NotFound);
                 mock.Requests.First()!.WasExpected.Should().BeFalse();
+            }
+            finally
+            {
+                File.Delete(path);
+            }
+        }
+
+        [Fact]
+        public async Task Does_not_replay_recording_for_different_request_url()
+        {
+            // Arrange
+            string path = Path.GetTempFileName();
+            const string recording = """
+                {
+                  "log": {
+                    "entries": [
+                      {
+                        "request": {
+                          "method": "POST",
+                          "url": "https://localhost/api/recorded"
+                        },
+                        "response": {
+                          "status": 201,
+                          "content": { "text": "b2s=", "encoding": "base64" }
+                        }
+                      }
+                    ]
+                  }
+                }
+                """;
+            File.WriteAllText(path, recording);
+            var mock = new HttpMock { FailOnUnexpectedCalls = false }.LoadRecordings(path);
+
+            try
+            {
+                // Act
+                HttpResponseMessage response = await mock.GetClient().PostAsync(
+                    "https://localhost/api/other",
+                    new StringContent("new"));
+
+                // Assert
+                response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+                mock.Requests.First()!.WasExpected.Should().BeFalse();
+            }
+            finally
+            {
+                File.Delete(path);
+            }
+        }
+
+        [Fact]
+        public void Recording_to_a_null_path_throws()
+        {
+            // Act
+            Action act = () => new HttpMock().RecordingTo(null!);
+
+            // Assert
+            act.Should().Throw<ArgumentNullException>();
+        }
+
+        [Fact]
+        public void Loading_recordings_from_a_null_path_throws()
+        {
+            // Act
+            Action act = () => new HttpMock().LoadRecordings(null!);
+
+            // Assert
+            act.Should().Throw<ArgumentNullException>();
+        }
+
+        [Fact]
+        public async Task Records_a_passed_through_request_and_its_response()
+        {
+            // Arrange
+            string path = Path.GetTempFileName();
+            using var origin = new LocalHttpServer(HttpStatusCode.Created, "text/plain", "pong");
+
+            try
+            {
+                var mock = new HttpMock().RecordingTo(path);
+
+                using var request = new HttpRequestMessage(HttpMethod.Post, origin.Url)
+                {
+                    Content = new StringContent("ping", Encoding.UTF8, "text/plain")
+                };
+                request.Headers.TryAddWithoutValidation("Cookie", "user=alice123");
+
+                // Act
+                HttpResponseMessage response = await mock.GetClient().SendAsync(request);
+
+                // Assert
+                response.StatusCode.Should().Be(HttpStatusCode.Created);
+                (await response.Content.ReadAsStringAsync()).Should().Be("pong");
+                mock.Requests.First()!.WasExpected.Should().BeTrue();
+
+                origin.ReceivedCookieHeader.Should().Be("user=alice123");
+                origin.ReceivedBody.Should().Be("ping");
+
+                string json = File.ReadAllText(path);
+                using JsonDocument document = JsonDocument.Parse(json);
+                JsonElement entry = document.RootElement.GetProperty("log").GetProperty("entries")[0];
+                entry.GetProperty("request").GetProperty("method").GetString().Should().Be("POST");
+
+                JsonElement requestHeaders = entry.GetProperty("request").GetProperty("headers");
+                requestHeaders.EnumerateArray()
+                    .Single(header => header.GetProperty("name").GetString() == "Cookie")
+                    .GetProperty("value").GetString().Should().Be("[REDACTED]");
+
+                entry.GetProperty("response").GetProperty("status").GetInt32().Should().Be(201);
+            }
+            finally
+            {
+                File.Delete(path);
+            }
+        }
+
+        [Fact]
+        public async Task Keeps_sensitive_header_values_when_configured_to_do_so()
+        {
+            // Arrange
+            string path = Path.GetTempFileName();
+            using var origin = new LocalHttpServer(HttpStatusCode.OK, "text/plain", "pong");
+
+            try
+            {
+                var mock = new HttpMock().RecordingTo(path).KeepSensitiveRecordingValues();
+
+                using var request = new HttpRequestMessage(HttpMethod.Get, origin.Url);
+                request.Headers.TryAddWithoutValidation("Cookie", "user=alice123");
+
+                // Act
+                await mock.GetClient().SendAsync(request);
+
+                // Assert
+                string json = File.ReadAllText(path);
+                using JsonDocument document = JsonDocument.Parse(json);
+                JsonElement requestHeaders = document.RootElement.GetProperty("log").GetProperty("entries")[0]
+                    .GetProperty("request").GetProperty("headers");
+
+                requestHeaders.EnumerateArray()
+                    .Single(header => header.GetProperty("name").GetString() == "Cookie")
+                    .GetProperty("value").GetString().Should().Be("user=alice123");
             }
             finally
             {
@@ -5025,4 +5183,72 @@ public class HttpMockSpecs
         }
     }
 
+}
+
+#nullable enable
+
+/// <summary>
+/// A minimal local HTTP server used to exercise Mockly's pass-through and recording behavior
+/// against a real network round-trip, without introducing any new package dependencies.
+/// </summary>
+internal sealed class LocalHttpServer : IDisposable
+{
+    private readonly HttpListener listener;
+
+    public LocalHttpServer(HttpStatusCode responseStatusCode, string responseContentType, string responseBody)
+    {
+        int port = GetFreeTcpPort();
+        Url = $"http://127.0.0.1:{port}/ping";
+
+        listener = new HttpListener();
+        listener.Prefixes.Add($"http://127.0.0.1:{port}/");
+        listener.Start();
+
+        listener.BeginGetContext(OnGetContext, null);
+
+        void OnGetContext(IAsyncResult result)
+        {
+            HttpListenerContext context = listener.EndGetContext(result);
+
+            using var reader = new StreamReader(context.Request.InputStream, context.Request.ContentEncoding);
+            ReceivedBody = reader.ReadToEnd();
+
+            // On .NET Framework, HttpListener parses the Cookie header into context.Request.Cookies
+            // and removes it from Headers, so fall back to reconstructing it from there.
+            ReceivedCookieHeader = context.Request.Headers["Cookie"]
+                ?? string.Join("; ", context.Request.Cookies.Cast<Cookie>().Select(cookie => $"{cookie.Name}={cookie.Value}"));
+            if (ReceivedCookieHeader.Length == 0)
+            {
+                ReceivedCookieHeader = null;
+            }
+
+            byte[] buffer = Encoding.UTF8.GetBytes(responseBody);
+            context.Response.StatusCode = (int)responseStatusCode;
+            context.Response.ContentType = responseContentType;
+            context.Response.ContentLength64 = buffer.Length;
+            context.Response.OutputStream.Write(buffer, 0, buffer.Length);
+            context.Response.OutputStream.Close();
+        }
+    }
+
+    public string Url { get; }
+
+    public string? ReceivedBody { get; private set; }
+
+    public string? ReceivedCookieHeader { get; private set; }
+
+    private static int GetFreeTcpPort()
+    {
+        var tcpListener = new System.Net.Sockets.TcpListener(IPAddress.Loopback, 0);
+        tcpListener.Start();
+        int port = ((IPEndPoint)tcpListener.LocalEndpoint).Port;
+        tcpListener.Stop();
+        return port;
+    }
+
+    public void Dispose()
+    {
+        listener.Stop();
+        listener.Close();
+    }
 }

--- a/Mockly.Specs/HttpMockSpecs.cs
+++ b/Mockly.Specs/HttpMockSpecs.cs
@@ -38,6 +38,57 @@ public class HttpMockSpecs
         }
 
         [Fact]
+        public async Task Serves_response_from_loaded_har_recording()
+        {
+            // Arrange
+            string path = Path.GetTempFileName();
+            const string recording = """
+                {
+                  "log": {
+                    "version": "1.2",
+                    "entries": [
+                      {
+                        "request": {
+                          "method": "GET",
+                          "url": "https://localhost/api/recorded"
+                        },
+                        "response": {
+                          "status": 201,
+                          "statusText": "Created",
+                          "headers": [],
+                          "content": {
+                            "size": 7,
+                            "mimeType": "text/plain",
+                            "text": "cmVjb3Jk",
+                            "encoding": "base64"
+                          }
+                        }
+                      }
+                    ]
+                  }
+                }
+                """;
+            File.WriteAllText(path, recording);
+
+            try
+            {
+                var mock = new HttpMock().LoadRecordings(path);
+
+                // Act
+                HttpResponseMessage response = await mock.GetClient().GetAsync("https://localhost/api/recorded");
+
+                // Assert
+                response.StatusCode.Should().Be(HttpStatusCode.Created);
+                (await response.Content.ReadAsStringAsync()).Should().Be("record");
+                mock.Requests.First()!.WasExpected.Should().BeTrue();
+            }
+            finally
+            {
+                File.Delete(path);
+            }
+        }
+
+        [Fact]
         public async Task Ignores_preceding_slashes_in_the_path()
         {
             // Arrange
@@ -4875,4 +4926,3 @@ public class HttpMockSpecs
     }
 
 }
-

--- a/Mockly.Specs/HttpMockSpecs.cs
+++ b/Mockly.Specs/HttpMockSpecs.cs
@@ -62,6 +62,7 @@ public class HttpMockSpecs
                             "text": "cmVjb3Jk",
                             "encoding": "base64"
                           }
+
                         }
                       }
                     ]
@@ -81,6 +82,105 @@ public class HttpMockSpecs
                 response.StatusCode.Should().Be(HttpStatusCode.Created);
                 (await response.Content.ReadAsStringAsync()).Should().Be("record");
                 mock.Requests.First()!.WasExpected.Should().BeTrue();
+            }
+            finally
+            {
+                File.Delete(path);
+            }
+        }
+
+        [Fact]
+        public async Task Serves_response_from_matching_post_recording()
+        {
+            // Arrange
+            string path = Path.GetTempFileName();
+            const string recording = """
+                {
+                  "log": {
+                    "entries": [
+                      {
+                        "request": {
+                          "method": "POST",
+                          "url": "https://localhost/api/recorded",
+                          "postData": {
+                            "mimeType": "application/json",
+                            "text": "eyJpZCI6MX0="
+                          }
+                        },
+                        "response": {
+                          "status": 202,
+                          "headers": [
+                            { "name": "X-Recorded", "value": "true" }
+                          ],
+                          "content": {
+                            "mimeType": "application/json",
+                            "text": "eyJvayI6dHJ1ZX0=",
+                            "encoding": "base64"
+                          }
+                        }
+                      }
+                    ]
+                  }
+                }
+                """;
+            File.WriteAllText(path, recording);
+
+            try
+            {
+                var mock = new HttpMock().LoadRecordings(path);
+
+                // Act
+                using var content = new StringContent("{\"id\":1}", Encoding.UTF8, "application/json");
+                HttpResponseMessage response = await mock.GetClient().PostAsync("https://localhost/api/recorded", content);
+
+                // Assert
+                response.StatusCode.Should().Be(HttpStatusCode.Accepted);
+                response.Headers.GetValues("X-Recorded").Should().ContainSingle("true");
+                (await response.Content.ReadAsStringAsync()).Should().Be("{\"ok\":true}");
+            }
+            finally
+            {
+                File.Delete(path);
+            }
+        }
+
+        [Fact]
+        public async Task Does_not_replay_recording_for_different_request_body()
+        {
+            // Arrange
+            string path = Path.GetTempFileName();
+            const string recording = """
+                {
+                  "log": {
+                    "entries": [
+                      {
+                        "request": {
+                          "method": "POST",
+                          "url": "https://localhost/api/recorded",
+                          "postData": { "text": "b2xk" }
+                        },
+                        "response": {
+                          "status": 201,
+                          "content": { "text": "b2s=", "encoding": "base64" }
+                        }
+                      }
+                    ]
+                  }
+                }
+                """;
+            File.WriteAllText(path, recording);
+            var mock = new HttpMock { FailOnUnexpectedCalls = false }.LoadRecordings(path);
+
+            try
+            {
+                // Act
+                HttpResponseMessage response = await mock.GetClient().PostAsync(
+                    "https://localhost/api/recorded",
+                    new StringContent("new"));
+
+                // Assert
+                response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+                mock.Requests.First()!.WasExpected.Should().BeFalse();
             }
             finally
             {

--- a/Mockly.Specs/HttpMockSpecs.cs
+++ b/Mockly.Specs/HttpMockSpecs.cs
@@ -22,7 +22,7 @@ namespace Mockly.Specs;
 public class HttpMockSpecs
 {
     /// <summary>
-    /// Writes a recording file asynchronously. <see cref="File.WriteAllTextAsync"/> is only available
+    /// Writes a recording file asynchronously. <c>File.WriteAllTextAsync</c> is only available
     /// starting with .NET Core, so net472 falls back to the synchronous overload.
     /// </summary>
     private static Task WriteRecordingAsync(string path, string contents)
@@ -32,6 +32,19 @@ public class HttpMockSpecs
 #else
         File.WriteAllText(path, contents);
         return Task.CompletedTask;
+#endif
+    }
+
+    /// <summary>
+    /// Reads a recording file asynchronously. <c>File.ReadAllTextAsync</c> is only available
+    /// starting with .NET Core, so net472 falls back to the synchronous overload.
+    /// </summary>
+    private static Task<string> ReadRecordingAsync(string path)
+    {
+#if NET8_0_OR_GREATER
+        return File.ReadAllTextAsync(path);
+#else
+        return Task.FromResult(File.ReadAllText(path));
 #endif
     }
 
@@ -278,10 +291,8 @@ public class HttpMockSpecs
             {
                 var mock = new HttpMock().RecordingTo(path);
 
-                using var request = new HttpRequestMessage(HttpMethod.Post, origin.Url)
-                {
-                    Content = new StringContent("ping", Encoding.UTF8, "text/plain")
-                };
+                using var request = new HttpRequestMessage(HttpMethod.Post, origin.Url);
+                request.Content = new StringContent("ping", Encoding.UTF8, "text/plain");
                 request.Headers.TryAddWithoutValidation("Cookie", "user=alice123");
 
                 // Act
@@ -295,7 +306,7 @@ public class HttpMockSpecs
                 origin.ReceivedCookieHeader.Should().Be("user=alice123");
                 origin.ReceivedBody.Should().Be("ping");
 
-                string json = File.ReadAllText(path);
+                string json = await ReadRecordingAsync(path);
                 using JsonDocument document = JsonDocument.Parse(json);
                 JsonElement entry = document.RootElement.GetProperty("log").GetProperty("entries")[0];
                 entry.GetProperty("request").GetProperty("method").GetString().Should().Be("POST");
@@ -331,7 +342,7 @@ public class HttpMockSpecs
                 await mock.GetClient().SendAsync(request);
 
                 // Assert
-                string json = File.ReadAllText(path);
+                string json = await ReadRecordingAsync(path);
                 using JsonDocument document = JsonDocument.Parse(json);
                 JsonElement requestHeaders = document.RootElement.GetProperty("log").GetProperty("entries")[0]
                     .GetProperty("request").GetProperty("headers");
@@ -5215,6 +5226,8 @@ internal sealed class LocalHttpServer : IDisposable
 
             // On .NET Framework, HttpListener parses the Cookie header into context.Request.Cookies
             // and removes it from Headers, so fall back to reconstructing it from there.
+            // CookieCollection only implements the non-generic IEnumerable on net472, so the cast
+            // below is required there even though it is redundant on net8.0.
             ReceivedCookieHeader = context.Request.Headers["Cookie"]
                 ?? string.Join("; ", context.Request.Cookies.Cast<Cookie>().Select(cookie => $"{cookie.Name}={cookie.Value}"));
             if (ReceivedCookieHeader.Length == 0)

--- a/Mockly/HttpArchive.cs
+++ b/Mockly/HttpArchive.cs
@@ -19,6 +19,7 @@ internal sealed class HttpArchive
 #pragma warning disable SA1516
 internal sealed class HttpArchiveLog
 {
+    // ReSharper disable once UnusedMember.Global -- part of the HAR 1.2 schema, kept for format compliance
     public string Version { get; init; } = "1.2";
     public List<HttpArchiveEntry> Entries { get; init; } = [];
 }
@@ -27,6 +28,8 @@ internal sealed class HttpArchiveEntry
 {
     public HttpArchiveRequest Request { get; init; } = new();
     public HttpArchiveResponse Response { get; init; } = new();
+
+    // ReSharper disable once UnusedAutoPropertyAccessor.Global -- part of the HAR schema, kept for format compliance
     public DateTime StartedDateTime { get; init; }
 }
 
@@ -34,6 +37,8 @@ internal sealed class HttpArchiveRequest
 {
     public string Method { get; init; } = string.Empty;
     public string Url { get; init; } = string.Empty;
+
+    // ReSharper disable once UnusedAutoPropertyAccessor.Global -- part of the HAR schema, kept for format compliance
     public List<HttpArchiveHeader> Headers { get; init; } = [];
     public HttpArchivePostData? PostData { get; init; }
 }
@@ -54,12 +59,14 @@ internal sealed class HttpArchiveHeader
 
 internal sealed class HttpArchivePostData
 {
+    // ReSharper disable once UnusedAutoPropertyAccessor.Global -- part of the HAR schema, kept for format compliance
     public string? MimeType { get; init; }
     public string? Text { get; init; }
 }
 
 internal sealed class HttpArchiveContent
 {
+    // ReSharper disable once UnusedAutoPropertyAccessor.Global -- part of the HAR schema, kept for format compliance
     public int Size { get; init; }
     public string? MimeType { get; init; }
     public string? Text { get; init; }
@@ -77,12 +84,14 @@ internal static class HttpArchiveConverter
     };
 
     public static async Task<HttpArchiveEntry> CreateEntryAsync(HttpRequestMessage request, HttpResponseMessage response,
-        RecordingValuePolicy valuePolicy)
+        RecordingValuePolicy valuePolicy, byte[]? requestBodyOverride)
     {
-        byte[] responseBody = response.Content is null
-            ? []
-            : await response.Content.ReadAsByteArrayAsync();
-        byte[]? requestBody = request.Content is null ? null : await request.Content.ReadAsByteArrayAsync();
+        byte[] responseBody = await response.Content.ReadAsByteArrayAsync();
+
+        // Prefer the caller-supplied bytes when available: on .NET Framework, HttpClientHandler
+        // disposes the request's content once it has been sent, so re-reading it here would throw.
+        byte[]? requestBody = requestBodyOverride
+            ?? (request.Content is null ? null : await request.Content.ReadAsByteArrayAsync());
 
         return new HttpArchiveEntry
         {
@@ -182,10 +191,7 @@ internal static class HttpArchiveConverter
     private static List<HttpArchiveHeader> GetHeaders(HttpResponseMessage response, RecordingValuePolicy valuePolicy)
     {
         var headers = response.Headers.ToList();
-        if (response.Content is not null)
-        {
-            headers.AddRange(response.Content.Headers);
-        }
+        headers.AddRange(response.Content.Headers);
 
         return GetHeaders(headers, valuePolicy);
     }

--- a/Mockly/HttpArchive.cs
+++ b/Mockly/HttpArchive.cs
@@ -117,7 +117,7 @@ internal static class HttpArchiveConverter
                 Content = new HttpArchiveContent
                 {
                     Size = responseBody.Length,
-                    MimeType = response.Content?.Headers.ContentType?.ToString(),
+                    MimeType = response.Content.Headers.ContentType?.ToString(),
                     Text = Convert.ToBase64String(responseBody),
                     Encoding = "base64"
                 }

--- a/Mockly/HttpArchive.cs
+++ b/Mockly/HttpArchive.cs
@@ -1,0 +1,216 @@
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text.Json;
+
+namespace Mockly;
+
+internal enum RecordingValuePolicy
+{
+    RedactSensitive,
+    KeepSensitive
+}
+
+internal sealed class HttpArchive
+{
+    public HttpArchiveLog Log { get; init; } = new();
+}
+
+#pragma warning disable SA1516
+internal sealed class HttpArchiveLog
+{
+    public string Version { get; init; } = "1.2";
+    public List<HttpArchiveEntry> Entries { get; init; } = [];
+}
+
+internal sealed class HttpArchiveEntry
+{
+    public HttpArchiveRequest Request { get; init; } = new();
+    public HttpArchiveResponse Response { get; init; } = new();
+    public DateTime StartedDateTime { get; init; }
+}
+
+internal sealed class HttpArchiveRequest
+{
+    public string Method { get; init; } = string.Empty;
+    public string Url { get; init; } = string.Empty;
+    public List<HttpArchiveHeader> Headers { get; init; } = [];
+    public HttpArchivePostData? PostData { get; init; }
+}
+
+internal sealed class HttpArchiveResponse
+{
+    public int Status { get; init; }
+    public string StatusText { get; init; } = string.Empty;
+    public List<HttpArchiveHeader> Headers { get; init; } = [];
+    public HttpArchiveContent Content { get; init; } = new();
+}
+
+internal sealed class HttpArchiveHeader
+{
+    public string Name { get; init; } = string.Empty;
+    public string Value { get; init; } = string.Empty;
+}
+
+internal sealed class HttpArchivePostData
+{
+    public string? MimeType { get; init; }
+    public string? Text { get; init; }
+}
+
+internal sealed class HttpArchiveContent
+{
+    public int Size { get; init; }
+    public string? MimeType { get; init; }
+    public string? Text { get; init; }
+    public string? Encoding { get; init; }
+}
+
+internal static class HttpArchiveConverter
+{
+    private static readonly HashSet<string> SensitiveHeaders = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "Authorization",
+        "Cookie",
+        "Proxy-Authorization",
+        "Set-Cookie"
+    };
+
+    public static async Task<HttpArchiveEntry> CreateEntryAsync(HttpRequestMessage request, HttpResponseMessage response,
+        RecordingValuePolicy valuePolicy)
+    {
+        byte[] responseBody = response.Content is null
+            ? []
+            : await response.Content.ReadAsByteArrayAsync();
+        byte[]? requestBody = request.Content is null ? null : await request.Content.ReadAsByteArrayAsync();
+
+        return new HttpArchiveEntry
+        {
+            StartedDateTime = DateTime.UtcNow,
+            Request = new HttpArchiveRequest
+            {
+                Method = request.Method.Method,
+                Url = request.RequestUri?.ToString() ?? string.Empty,
+                Headers = GetHeaders(request, valuePolicy),
+                PostData = request.Content is null
+                    ? null
+                    : new HttpArchivePostData
+                    {
+                        MimeType = request.Content.Headers.ContentType?.ToString(),
+                        Text = Convert.ToBase64String(requestBody ?? [])
+                    }
+            },
+            Response = new HttpArchiveResponse
+            {
+                Status = (int)response.StatusCode,
+                StatusText = response.ReasonPhrase ?? string.Empty,
+                Headers = GetHeaders(response, valuePolicy),
+                Content = new HttpArchiveContent
+                {
+                    Size = responseBody.Length,
+                    MimeType = response.Content?.Headers.ContentType?.ToString(),
+                    Text = Convert.ToBase64String(responseBody),
+                    Encoding = "base64"
+                }
+            }
+        };
+    }
+
+    public static HttpResponseMessage CreateResponse(HttpArchiveEntry entry)
+    {
+        byte[] body = entry.Response.Content.Encoding == "base64"
+            ? Convert.FromBase64String(entry.Response.Content.Text ?? string.Empty)
+            : System.Text.Encoding.UTF8.GetBytes(entry.Response.Content.Text ?? string.Empty);
+
+        var response = new HttpResponseMessage((HttpStatusCode)entry.Response.Status)
+        {
+            ReasonPhrase = entry.Response.StatusText,
+            Content = new ByteArrayContent(body)
+        };
+
+        if (entry.Response.Content.MimeType is not null)
+        {
+            response.Content.Headers.ContentType = MediaTypeHeaderValue.Parse(entry.Response.Content.MimeType);
+        }
+
+        AddHeaders(response, entry.Response.Headers);
+        return response;
+    }
+
+    public static bool Matches(HttpArchiveEntry entry, RequestInfo request)
+    {
+        if (!string.Equals(entry.Request.Method, request.Method.Method, StringComparison.OrdinalIgnoreCase) ||
+            !string.Equals(entry.Request.Url, request.Uri?.ToString(), StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        if (entry.Request.PostData is null)
+        {
+            return request.RawBody is null or { Length: 0 };
+        }
+
+        string requestBody = Convert.ToBase64String(request.RawBody ?? []);
+        return string.Equals(entry.Request.PostData.Text ?? string.Empty, requestBody, StringComparison.Ordinal);
+    }
+
+    public static HttpArchive Parse(string json)
+    {
+        return JsonSerializer.Deserialize<HttpArchive>(json, new JsonSerializerOptions { PropertyNameCaseInsensitive = true }) ??
+            throw new InvalidDataException("The recording file does not contain a valid HTTP archive.");
+    }
+
+    public static string Serialize(IEnumerable<HttpArchiveEntry> entries)
+    {
+        return JsonSerializer.Serialize(new HttpArchive
+        {
+            Log = new HttpArchiveLog { Entries = entries.ToList() }
+        }, new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase, WriteIndented = true });
+    }
+
+    private static List<HttpArchiveHeader> GetHeaders(HttpRequestMessage request, RecordingValuePolicy valuePolicy)
+    {
+        var headers = request.Headers.ToList();
+        if (request.Content is not null)
+        {
+            headers.AddRange(request.Content.Headers);
+        }
+
+        return GetHeaders(headers, valuePolicy);
+    }
+
+    private static List<HttpArchiveHeader> GetHeaders(HttpResponseMessage response, RecordingValuePolicy valuePolicy)
+    {
+        var headers = response.Headers.ToList();
+        if (response.Content is not null)
+        {
+            headers.AddRange(response.Content.Headers);
+        }
+
+        return GetHeaders(headers, valuePolicy);
+    }
+
+    private static List<HttpArchiveHeader> GetHeaders(IEnumerable<KeyValuePair<string, IEnumerable<string>>> headers,
+        RecordingValuePolicy valuePolicy)
+    {
+        return headers.SelectMany(header => header.Value.Select(value => new HttpArchiveHeader
+        {
+            Name = header.Key,
+            Value = valuePolicy == RecordingValuePolicy.RedactSensitive && SensitiveHeaders.Contains(header.Key)
+                ? "[REDACTED]"
+                : value
+        })).ToList();
+    }
+
+    private static void AddHeaders(HttpResponseMessage response, IEnumerable<HttpArchiveHeader> headers)
+    {
+        foreach (HttpArchiveHeader header in headers)
+        {
+            if (!response.Headers.TryAddWithoutValidation(header.Name, header.Value))
+            {
+                response.Content.Headers.TryAddWithoutValidation(header.Name, header.Value);
+            }
+        }
+    }
+}
+#pragma warning restore SA1516

--- a/Mockly/HttpMock.cs
+++ b/Mockly/HttpMock.cs
@@ -19,8 +19,18 @@ namespace Mockly;
 /// </summary>
 public class HttpMock
 {
+    private static readonly HttpClient PassThroughClient = new(new HttpClientHandler
+    {
+        CheckCertificateRevocationList = true
+    });
+
     private readonly List<RequestMock> mocks = new();
+    private readonly List<HttpArchiveEntry> replayRecordings = new();
+    private readonly List<HttpArchiveEntry> recordedEntries = new();
     private RequestMockBuilder? previousBuilder;
+    private string? recordingPath;
+    private bool passThroughUnmatched;
+    private RecordingValuePolicy recordingValuePolicy = RecordingValuePolicy.RedactSensitive;
 
     /// <summary>
     /// Gets or sets whether to fail when unexpected HTTP requests are detected.
@@ -43,6 +53,56 @@ public class HttpMock
     /// Gets all captured requests.
     /// </summary>
     public RequestCollection Requests { get; } = new();
+
+    /// <summary>
+    /// Configures unmatched requests to be sent to the real server instead of failing.
+    /// </summary>
+    public HttpMock PassThroughUnmatched()
+    {
+        passThroughUnmatched = true;
+        FailOnUnexpectedCalls = false;
+        return this;
+    }
+
+    /// <summary>
+    /// Records pass-through requests and responses in a HAR-compatible JSON file.
+    /// Sensitive headers are redacted by default; call <see cref="KeepSensitiveRecordingValues"/> to retain them.
+    /// </summary>
+    public HttpMock RecordingTo(string path)
+    {
+        if (path is null)
+        {
+            throw new ArgumentNullException(nameof(path));
+        }
+
+        recordingPath = path;
+        return PassThroughUnmatched();
+    }
+
+    /// <summary>
+    /// Allows sensitive header values to be written to subsequent recordings.
+    /// </summary>
+    public HttpMock KeepSensitiveRecordingValues()
+    {
+        recordingValuePolicy = RecordingValuePolicy.KeepSensitive;
+        return this;
+    }
+
+    /// <summary>
+    /// Loads a HAR-compatible JSON file and serves matching requests without using the network.
+    /// </summary>
+    public HttpMock LoadRecordings(string path)
+    {
+        if (path is null)
+        {
+            throw new ArgumentNullException(nameof(path));
+        }
+
+        HttpArchive archive = HttpArchiveConverter.Parse(File.ReadAllText(path));
+        replayRecordings.Clear();
+        replayRecordings.AddRange(archive.Log.Entries);
+        return this;
+    }
 
     /// <summary>
     /// Starts building a mock for requests using the specified HTTP <paramref name="method"/>.
@@ -350,12 +410,76 @@ public class HttpMock
             ExceptionDispatchInfo.Capture(capturedRequest.SimulatedFailure).Throw();
         }
 
+        if (!foundMatch && replayRecordings.Count > 0)
+        {
+            HttpArchiveEntry? recording = replayRecordings.FirstOrDefault(entry => HttpArchiveConverter.Matches(entry, request));
+            if (recording is not null)
+            {
+                capturedRequest.Response.Dispose();
+                capturedRequest.Response = HttpArchiveConverter.CreateResponse(recording);
+                foundMatch = true;
+                capturedRequest.WasExpected = true;
+            }
+        }
+
+        if (!foundMatch && passThroughUnmatched)
+        {
+            using HttpRequestMessage forwardedRequest = await CloneRequest(httpRequest, request.RawBody);
+            HttpResponseMessage response = await PassThroughClient.SendAsync(forwardedRequest, cancellationToken);
+            capturedRequest.Response.Dispose();
+            capturedRequest.Response = response;
+            capturedRequest.WasExpected = true;
+            foundMatch = true;
+
+            if (recordingPath is not null)
+            {
+                await RecordAsync(response, forwardedRequest);
+            }
+        }
+
         if (!foundMatch && FailOnUnexpectedCalls)
         {
             await ThrowDetailedException(request);
         }
 
         return capturedRequest.Response;
+    }
+
+    private async Task RecordAsync(HttpResponseMessage response, HttpRequestMessage request)
+    {
+        HttpArchiveEntry entry = await HttpArchiveConverter.CreateEntryAsync(request, response, recordingValuePolicy);
+        recordedEntries.Add(entry);
+        Directory.CreateDirectory(Path.GetDirectoryName(Path.GetFullPath(recordingPath!))!);
+#if NET8_0_OR_GREATER
+        await File.WriteAllTextAsync(recordingPath!, HttpArchiveConverter.Serialize(recordedEntries));
+#else
+        File.WriteAllText(recordingPath!, HttpArchiveConverter.Serialize(recordedEntries));
+#endif
+    }
+
+    private static async Task<HttpRequestMessage> CloneRequest(HttpRequestMessage request, byte[]? rawBody)
+    {
+        var clone = new HttpRequestMessage(request.Method, request.RequestUri)
+        {
+            Version = request.Version
+        };
+
+        foreach (KeyValuePair<string, IEnumerable<string>> header in request.Headers)
+        {
+            clone.Headers.TryAddWithoutValidation(header.Key, header.Value);
+        }
+
+        if (request.Content is not null)
+        {
+            byte[] body = rawBody ?? await request.Content.ReadAsByteArrayAsync();
+            clone.Content = new ByteArrayContent(body);
+            foreach (KeyValuePair<string, IEnumerable<string>> header in request.Content.Headers)
+            {
+                clone.Content.Headers.TryAddWithoutValidation(header.Key, header.Value);
+            }
+        }
+
+        return clone;
     }
 
     /// <summary>
@@ -452,7 +576,7 @@ public class HttpMock
     private async Task<RequestInfo> BuildRequestInfo(HttpRequestMessage httpRequest)
     {
         byte[]? rawBody = null;
-        if (PrefetchBody && httpRequest.Content is not null)
+        if ((PrefetchBody || passThroughUnmatched || replayRecordings.Count > 0) && httpRequest.Content is not null)
         {
             rawBody = await httpRequest.Content.ReadAsByteArrayAsync();
         }

--- a/Mockly/HttpMock.cs
+++ b/Mockly/HttpMock.cs
@@ -21,7 +21,12 @@ public class HttpMock
 {
     private static readonly HttpClient PassThroughClient = new(new HttpClientHandler
     {
-        CheckCertificateRevocationList = true
+        CheckCertificateRevocationList = true,
+
+        // Mockly forwards the original request's headers verbatim, including any Cookie header.
+        // Leaving cookie handling enabled would let the handler's cookie container silently
+        // override or drop that header.
+        UseCookies = false
     });
 
     private readonly List<RequestMock> mocks = new();
@@ -70,12 +75,7 @@ public class HttpMock
     /// </summary>
     public HttpMock RecordingTo(string path)
     {
-        if (path is null)
-        {
-            throw new ArgumentNullException(nameof(path));
-        }
-
-        recordingPath = path;
+        recordingPath = path ?? throw new ArgumentNullException(nameof(path));
         return PassThroughUnmatched();
     }
 
@@ -433,7 +433,7 @@ public class HttpMock
 
             if (recordingPath is not null)
             {
-                await RecordAsync(response, forwardedRequest);
+                await RecordAsync(response, forwardedRequest, request.RawBody);
             }
         }
 
@@ -445,9 +445,9 @@ public class HttpMock
         return capturedRequest.Response;
     }
 
-    private async Task RecordAsync(HttpResponseMessage response, HttpRequestMessage request)
+    private async Task RecordAsync(HttpResponseMessage response, HttpRequestMessage request, byte[]? requestBody)
     {
-        HttpArchiveEntry entry = await HttpArchiveConverter.CreateEntryAsync(request, response, recordingValuePolicy);
+        HttpArchiveEntry entry = await HttpArchiveConverter.CreateEntryAsync(request, response, recordingValuePolicy, requestBody);
         recordedEntries.Add(entry);
         Directory.CreateDirectory(Path.GetDirectoryName(Path.GetFullPath(recordingPath!))!);
 #if NET8_0_OR_GREATER

--- a/README.md
+++ b/README.md
@@ -166,21 +166,6 @@ patches.Count.Should().Be(3);
 patches.First().Path.Should().Contain("/api/update");
 ```
 
-### 🔁 Record and Replay
-
-Record unmatched traffic against a real service and replay it later without network access. Recordings use a
-HAR-compatible JSON format and redact sensitive headers by default.
-
-```csharp
-mock.PassThroughUnmatched()
-    .RecordingTo("Recordings/github.json");
-
-// In the offline test:
-mock.LoadRecordings("Recordings/github.json");
-```
-
-Call `KeepSensitiveRecordingValues()` before `RecordingTo` only when sensitive header values are safe to store.
-
 ### ✅ Powerful Assertions
 
 ```csharp

--- a/README.md
+++ b/README.md
@@ -166,6 +166,21 @@ patches.Count.Should().Be(3);
 patches.First().Path.Should().Contain("/api/update");
 ```
 
+### 🔁 Record and Replay
+
+Record unmatched traffic against a real service and replay it later without network access. Recordings use a
+HAR-compatible JSON format and redact sensitive headers by default.
+
+```csharp
+mock.PassThroughUnmatched()
+    .RecordingTo("Recordings/github.json");
+
+// In the offline test:
+mock.LoadRecordings("Recordings/github.json");
+```
+
+Call `KeepSensitiveRecordingValues()` before `RecordingTo` only when sensitive header values are safe to store.
+
 ### ✅ Powerful Assertions
 
 ```csharp

--- a/website/docs/advanced.md
+++ b/website/docs/advanced.md
@@ -151,6 +151,53 @@ mock.ForPost()
 - **When to disable**: Turn it off for scenarios with large or streaming content where reading the body up front is expensive or undesirable. In that case, `RequestInfo.Body` will be `null` unless your own predicate reads it.
 - **Impact on assertions**: Body-based assertions require the body to be available. Keep `PrefetchBody` enabled if you plan to assert on the request body after the call.
 
+## Record and Replay
+
+Record unmatched requests against a real service and replay them later without a network connection. Recording files use
+the [HTTP Archive (HAR)](https://w3c.github.io/web-performance/specs/HAR/Overview.html) JSON format.
+
+### Recording Requests
+
+Use `RecordingTo` to send unmatched requests to the real service and write their requests and responses to a file:
+
+```csharp
+using var mock = new HttpMock()
+    .RecordingTo("Recordings/github.json");
+
+HttpClient client = mock.GetClient();
+HttpResponseMessage response = await client.GetAsync(
+    "https://api.github.com/repos/dennisdoomen/mockly/issues");
+```
+
+`RecordingTo` enables pass-through requests. Configured mocks still take precedence, so Mockly records only unmatched
+requests.
+
+Mockly replaces the values of `Authorization`, `Cookie`, `Proxy-Authorization`, and `Set-Cookie` headers with
+`[REDACTED]`. Call `KeepSensitiveRecordingValues` before `RecordingTo` only if it is safe to store the values:
+
+```csharp
+using var mock = new HttpMock()
+    .KeepSensitiveRecordingValues()
+    .RecordingTo("Recordings/github.json");
+```
+
+### Replaying Requests
+
+Use `LoadRecordings` to serve responses from a recording without contacting the real service:
+
+```csharp
+using var mock = new HttpMock()
+    .LoadRecordings("Recordings/github.json");
+
+HttpClient client = mock.GetClient();
+HttpResponseMessage response = await client.GetAsync(
+    "https://api.github.com/repos/dennisdoomen/mockly/issues");
+```
+
+Mockly selects a recording by HTTP method and exact URL. If the recording contains a request body, Mockly also requires
+the request body to match. If no recording matches, Mockly handles the request as an unexpected request. You can add
+`PassThroughUnmatched` to contact the real service for missing recordings.
+
 ## Limiting Mock Invocations
 
 Sometimes you want a mock to respond only a limited number of times. You can restrict a mock using the fluent methods `Once()`, `Twice()`, or `Times(int count)` on the request builder.


### PR DESCRIPTION
## Why

Tests that depend on a real HTTP service are slower, less repeatable, and cannot run offline. This adds a record-and-replay workflow for unmatched requests.

## What changed

- Add `PassThroughUnmatched()` to forward unmatched requests to the real service.
- Add `RecordingTo(path)` to save pass-through traffic as HAR-compatible JSON.
- Redact sensitive headers by default, with `KeepSensitiveRecordingValues()` as an explicit opt-in.
- Add `LoadRecordings(path)` to replay matching requests without network access.
- Match replay entries by HTTP method, URL, and recorded request body when present.
- Add coverage for serving a response from a loaded recording and update the public API approvals.
- Document the workflow in the README.

The existing mock matching pipeline remains the source of truth. Recordings are only used after configured mocks have been checked, and pass-through is enabled explicitly.