### PR TITLE
Document features introduced since Mockly 1.8

### DIFF
--- a/website/docs/advanced.md
+++ b/website/docs/advanced.md
@@ -253,6 +253,42 @@ mock.ForGet()
 - If `HttpClient.Timeout` is shorter than the delay, the request throws a `TaskCanceledException`, just like a real `HttpClient`.
 - If the `CancellationToken` passed to the request is cancelled while the delay is in progress, an `OperationCanceledException` is thrown.
 
+## Simulating Network Failures
+
+Use `ThrowsException` or `TimesOut` to simulate a network-level failure instead of returning a response. This lets
+you verify retry, circuit-breaker and other resilience behavior without relying on a real, flaky network.
+
+```csharp
+var mock = new HttpMock();
+
+mock.ForGet()
+    .WithPath("/flaky")
+    .ThrowsException<HttpRequestException>();
+```
+
+Throw a specific exception instance instead:
+
+```csharp
+mock.ForGet()
+    .WithPath("/flaky")
+    .ThrowsException(new HttpRequestException("connection reset"));
+```
+
+Simulate an `HttpClient` timeout, which throws a `TaskCanceledException`:
+
+```csharp
+mock.ForGet()
+    .WithPath("/slow")
+    .TimesOut();
+```
+
+### Behavior Notes
+
+- The exception is propagated to the `HttpClient` caller rather than being converted into a `500 Internal Server Error` response.
+- The matching request is still recorded (e.g. in `HttpMock.Requests`) before the exception is thrown.
+- `ThrowsException(Exception)` throws the same instance on every matching invocation; `ThrowsException<TException>()` creates a fresh instance each time.
+- Combine with invocation limits (`Once()`, `Times(n)`) to fail only the first few calls before succeeding.
+
 ## Request Collection
 
 Capture requests for specific mocks:

--- a/website/docs/usage.md
+++ b/website/docs/usage.md
@@ -26,6 +26,23 @@ mock.ForGet()
 HttpClient client = mock.GetClient(); // BaseAddress defaults to https://localhost/
 ```
 
+## Import From cURL
+
+Bootstrap a mock from an existing `curl` command, such as the output of a browser's "Copy as cURL":
+
+```csharp
+mock.ImportFromCurl("""
+    curl -X POST https://api.example.com/users \
+      -H 'Content-Type: application/json' \
+      --data-raw '{"name":"mockly"}'
+    """)
+    .RespondsWithStatus(HttpStatusCode.Created);
+```
+
+The method (`-X`), URL, headers (`-H`) and body (`-d`/`--data`/`--data-raw`) are translated into the equivalent
+matching configuration. When no method is specified, `POST` is assumed if a body is present and `GET` otherwise.
+Attach a response to the returned builder, just like any other mock, to complete the configuration.
+
 ## Getting an HttpClient, IHttpClientFactory or HttpMessageHandler
 
 Mockly provides three ways to wire the mock into your code under test:
@@ -332,6 +349,38 @@ mock.ForGet()
         response.Headers.Add("X-Custom-Header", "value");
         response.Content = new StringContent("Custom content");
         return response;
+    });
+```
+
+A custom responder can also be asynchronous, which is useful when producing the response requires awaiting
+something (e.g. reading a file or calling another service):
+
+```csharp
+mock.ForGet()
+    .WithPath("/api/custom")
+    .RespondsWith(async request =>
+    {
+        string content = await File.ReadAllTextAsync("response.json");
+        return new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent(content)
+        };
+    });
+```
+
+Add a `CancellationToken` parameter to observe the token flowing from the HTTP pipeline, for example to pass it on
+to an awaited call:
+
+```csharp
+mock.ForGet()
+    .WithPath("/api/custom")
+    .RespondsWith(async (request, cancellationToken) =>
+    {
+        string content = await File.ReadAllTextAsync("response.json", cancellationToken);
+        return new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent(content)
+        };
     });
 ```
 


### PR DESCRIPTION
## Why

The website was missing documentation for several features introduced in Mockly releases 1.8 and later. This makes the release-to-documentation coverage complete for current users.

## What changed

- Documented importing request configuration from browser-generated cURL commands.
- Added examples for asynchronous custom responders and `CancellationToken` flow.
- Documented simulated network failures with `ThrowsException`, `ThrowsException<TException>`, and `TimesOut`.

The existing documentation for sequenced responses, raw request bodies, textual body handling, response latency, and record/replay remains in place.

## Validation

- Docusaurus production build completed successfully.
- Confirmed the new sections are present in the generated website output.